### PR TITLE
32 experiment add soit py deps

### DIFF
--- a/src/IFTPipeline.jl
+++ b/src/IFTPipeline.jl
@@ -20,13 +20,17 @@ include("preprocess.jl")
 include("feature-extraction.jl")
 include("tracker.jl")
 
-const np = PyNULL()
-const pyproj = PyNULL()
-const rasterio = PyNULL()
+"""
+    __init__()
+
+Initialize the Python dependencies for the pipeline. This function is called automatically when the module is loaded for the first time. See the help for `__init__` for more information.
+"""
 function __init__()
-    copy!(np, pyimport_conda("numpy", "numpy=1.25.0"))
-    copy!(pyproj, pyimport_conda("pyproj", "pyproj=3.6.0"))
-    copy!(rasterio, pyimport_conda("rasterio", "rasterio=1.3.7"))
+    pyimport_conda("numpy", "numpy=1.25.0")
+    pyimport_conda("pyproj", "pyproj=3.6.0")
+    pyimport_conda("rasterio", "rasterio=1.3.7")
+    pyimport_conda("requests", "requests=2.31.0")
+    pyimport_conda("skyfield", "skyfield=1.45.0")
 end
 
 export cache_vector, sharpen,

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"
+Conda = "8f4d0f93-b110-5947-807f-2305c1781a2d"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,7 @@ using Pkg
 using Random
 using Serialization
 using Test
+using Conda
 include(joinpath(@__DIR__, "config.jl"))
 
 function test_similarity(imgA::BitMatrix, imgB::BitMatrix, error_rate=0.005)
@@ -34,7 +35,7 @@ testnames = [n[6:(end-3)] for n in alltests]
 
 to_test = alltests # uncomment this line to run all tests or add individual files below
 [
-    "test-h5.jl"
+    "test-pydeps.jl"
 ]
 
 # Run the tests

--- a/test/test-pydeps.jl
+++ b/test/test-pydeps.jl
@@ -1,0 +1,7 @@
+@testset "python deps" begin
+    depslatlon = ["numpy", "pyproj", "rasterio"]
+    depssoit = ["requests", "skyfield"]
+    deps = vcat(depslatlon, depssoit)
+    pkgs = Conda._installed_packages()
+    @test all([dep in pkgs for dep in deps])
+end


### PR DESCRIPTION
#32 

Add soit py deps to Julia's default python.

See path with `julia -e "using Conda; @info Conda.PYTHONDIR"`. In the oscar shell one gets something like this
```julia
[cpaniagu@login007 ~]$ PYPATH=$(julia -e "using Conda; println(Conda.PYTHONDIR)")
[cpaniagu@login007 ~]$ echo $PYPATH
/users/cpaniagu/.julia/conda/3/x86_64/bin
[cpaniagu@login007 ~]$ 
```