### PR TITLE
update: latest cylc version

### DIFF
--- a/config/ift-env.yaml
+++ b/config/ift-env.yaml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
 
 dependencies:
-  - cylc-flow=8.3
+  - cylc-flow=8.2.1


### PR DESCRIPTION
I misread the current version (8.1.3) I was testing with on #45 . This brings the cylc version up to latest in the conda install yaml.