### PR TITLE
Feat param cycling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ resources/*
 results/*
 !results/README.md
 
+workflow/cylc-run/*
 workflow/report/*
 !workflow/report/README.md
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Cylc is used to encode the entire pipeline from start to finish and relies on th
    - [ ] It is a good idea to reset the Singularity cache dir as specified [here](https://docs.ccv.brown.edu/oscar/singularity-containers/building-images)
 
    - [ ] first update the parameters at the top of the `flow.cylc` file:
+     - job_id # just enter `0` for one set of parameters or `0..n` for cycling
      - startdate
      - enddate
      - crs
@@ -48,6 +49,7 @@ Cylc is used to encode the entire pipeline from start to finish and relies on th
      - maxfloearea
      - project_dir
      **Note:** bounding box format = top_left_x top_left_y bottom_right_x bottom_right_y (x = lat(wgs84) or easting(epsg3413),  y = lon(wgs84) or northing(epsg3413))
+     **Note:** if cycling through more than one set of parameters, enter values separated by a comma, e.g., `startdate = 2022-05-04,2022-05-08`
    - [ ] then, build the workflow, run it, and open the Terminal-based User Interface (TUI) to monitor the progress of each task. 
     ![TUI example](./tui-example.png)
 

--- a/config/cylc_hpc/flow.cylc
+++ b/config/cylc_hpc/flow.cylc
@@ -9,14 +9,12 @@
     initial cycle point = 1
     [[graph]]
         R1 = """
-            mkpaths & pullfetchimage & pulljuliaimage => fetchdata<startdate,enddate> & soit<startdate,enddate> #=> landmask => preprocess => extractfeatures => tracking & exportH5
+            mkpaths<startdate> & pullfetchimage & pulljuliaimage => fetchdata<startdate,enddate> & soit<startdate,enddate> #=> landmask => preprocess => extractfeatures => tracking & exportH5
              """
 [runtime]
     [[root]]
         [[[environment]]]
             # Update these variables with your run parameters
-            #startdate = $startdate
-            #enddate = $enddate
             crs = "wgs84" #epsg3413 for polar stereographic
             bounding_box = "78.186394 38.250605 70.749318 15.32373"
             centroid_x = "75"
@@ -38,9 +36,10 @@
             tracker_dir = $results_dir/"tracker"
             h5_dir = $preprocess_dir/"hdf5-files"
             
-    [[mkpaths]]
+    [[mkpaths<startdate>]]
         script = """
-            mkdir -p $soit_dir
+            mkdir -p $fetchdata_dir/${CYLC_TASK_PARAM_startdate}
+            mkdir -p $soit_dir/${CYLC_TASK_PARAM_startdate}
             mkdir -p $landmask_dir
             mkdir -p $preprocess_dir
             mkdir -p $tracker_dir
@@ -52,11 +51,11 @@
         """
     [[fetchdata<startdate><enddate>]]
         script = """
-            singularity exec --bind $fetchdata_dir:/tmp $project_dir/fetchdata.simg /usr/local/bin/fetchdata.sh -o /tmp -s $startdate -e $enddate -c $crs $bounding_box
+            singularity exec --bind $fetchdata_dir/${CYLC_TASK_PARAM_startdate}:/tmp $project_dir/fetchdata.simg /usr/local/bin/fetchdata.sh -o /tmp -s ${CYLC_TASK_PARAM_startdate} -e ${CYLC_TASK_PARAM_enddate} -c $crs $bounding_box
         """
     [[soit<startdate><enddate>]]
         script = """
-            singularity exec --bind $soit_dir:/tmp $project_dir/fetchdata.simg python3 /usr/local/bin/pass_time_cylc.py --startdate $startdate --enddate $enddate --csvoutpath /tmp --centroid_x $centroid_x --centroid_y $centroid_y --SPACEUSER $SPACEUSER --SPACEPSWD $SPACEPSWD
+            singularity exec --bind $soit_dir/${CYLC_TASK_PARAM_startdate}:/tmp $project_dir/fetchdata.simg python3 /usr/local/bin/pass_time_cylc.py --startdate ${CYLC_TASK_PARAM_startdate} --enddate ${CYLC_TASK_PARAM_enddate} --csvoutpath /tmp --centroid_x $centroid_x --centroid_y $centroid_y --SPACEUSER $SPACEUSER --SPACEPSWD $SPACEPSWD
         """
     [[pulljuliaimage]]
         script = """

--- a/config/cylc_hpc/flow.cylc
+++ b/config/cylc_hpc/flow.cylc
@@ -2,28 +2,30 @@
     allow implicit tasks = True
 [task parameters]
     # Update these variables with your run parameters
-    startdate = 2022-05-04, 2022-05-08
-    enddate = 2022-05-09, 2022-05-12
-    bbindex = 0..1
+    job_id = 0..1
+
 [scheduling]
     cycling mode = integer
     initial cycle point = 1
     [[graph]]
         R1 = """
-            fetchdata<startdate,enddate,bbindex>
-            #mkpaths<startdate> & pullfetchimage & pulljuliaimage => fetchdata<startdate,enddate> & soit<startdate,enddate> #=> landmask => preprocess => extractfeatures => tracking & exportH5
+            
+            mkpaths<job_id> => fetchdata<job_id> #& pullfetchimage & pulljuliaimage => fetchdata<job_id> #& soit<job_id> #=> landmask => preprocess => extractfeatures => tracking & exportH5
         """
 [runtime]
     [[root]]
         [[[environment]]]
             # Update these variables with your run parameters
+            startdate = ("2022-05-04" "2022-05-08")
+            enddate = ("2022-05-09" "2022-05-12")
             crs = "wgs84" #epsg3413 for polar stereographic
-            #bounding_box=("78,38,70,15" "77,37,69,14")
+            bounding_box=("78,38,70,15" "77,37,69,14")
             centroid_x = "75"
             centroid_y = "20"
             minfloearea = "300"
             maxfloearea = "90000"
             project_dir = "~/ice-floe-tracker-pipeline"
+            #input_data = (())
 
             # Recommend using these default paths for output
             julia_exec = "/usr/local/julia/bin/julia"
@@ -38,10 +40,10 @@
             tracker_dir = $results_dir/"tracker"
             h5_dir = $preprocess_dir/"hdf5-files"
             
-    [[mkpaths<startdate>]]
+    [[mkpaths<job_id>]]
         script = """
-            mkdir -p $fetchdata_dir/${CYLC_TASK_PARAM_startdate}
-            mkdir -p $soit_dir/${CYLC_TASK_PARAM_startdate}
+            mkdir -p $fetchdata_dir/${CYLC_TASK_PARAM_job_id}
+            mkdir -p $soit_dir/${CYLC_TASK_PARAM_job_id}
             mkdir -p $landmask_dir
             mkdir -p $preprocess_dir
             mkdir -p $tracker_dir
@@ -53,16 +55,23 @@
             apptainer build --force $project_dir/fetchdata.simg docker://brownccv/icefloetracker-fetchdata:main
         """
 
-    [[fetchdata<startdate,enddate,bbindex>]]
+    [[fetchdata<job_id>]]
         script = """
-            bounding_box=("78.1,38.2,70.3,15.4" "77.1,37.2,69.3,14.4")
-            i=${CYLC_TASK_PARAM_bbindex}
-            echo ${bounding_box[i]}
+            i=${CYLC_TASK_PARAM_job_id}
 
-            singularity exec --bind $fetchdata_dir/${CYLC_TASK_PARAM_startdate}:/tmp $project_dir/fetchdata.simg /usr/local/bin/fetchdata.sh -o /tmp -s ${CYLC_TASK_PARAM_startdate} -e ${CYLC_TASK_PARAM_enddate} -c $crs -b ${bounding_box[i]}
+            bounding_box_test=("78,38,70,15" "77,37,69,14")
+            bounding_box_env=${bounding_box[0]} #from cylc env var
+            echo "bounding_box = ${bounding_box[0]}" #from env directly
+            echo "bounding_box_env = ${bounding_box_env}" #from env unpacked
+            echo "bounding_box_test = ${bounding_box_test[0]}" #from this script block
+
+            startdate_env=$startdate
+            enddate_env=$enddate
+            
+            singularity exec --bind $fetchdata_dir/${CYLC_TASK_PARAM_job_id}:/tmp $project_dir/fetchdata.simg /usr/local/bin/fetchdata.sh -o /tmp -s ${startdate_env[$i]} -e ${enddate_env[$i]} -c $crs -b ${bounding_box_env}
         """
 
-    [[soit<startdate><enddate>]]
+    [[soit<job_id>]]
         script = """
             singularity exec --bind $soit_dir/${CYLC_TASK_PARAM_startdate}:/tmp $project_dir/fetchdata.simg python3 /usr/local/bin/pass_time_cylc.py --startdate ${CYLC_TASK_PARAM_startdate} --enddate ${CYLC_TASK_PARAM_enddate} --csvoutpath /tmp --centroid_x $centroid_x --centroid_y $centroid_y --SPACEUSER $SPACEUSER --SPACEPSWD $SPACEPSWD
         """

--- a/config/cylc_hpc/flow.cylc
+++ b/config/cylc_hpc/flow.cylc
@@ -9,17 +9,16 @@
     initial cycle point = 1
     [[graph]]
         R1 = """
-            
             global_setup => mkpaths<job_id> => fetchdata<job_id> #& pullfetchimage & pulljuliaimage => fetchdata<job_id> #& soit<job_id> #=> landmask => preprocess => extractfeatures => tracking & exportH5
         """
 [runtime]
     [[root]]
         [[[environment]]]
             # Update these variables with your run parameters
-            startdate = ("2022-05-04" "2022-05-08")
-            enddate = ("2022-05-09" "2022-05-12")
+            startdate = 2022-05-04,2022-05-08
+            enddate = 2022-05-09,2022-05-12
             crs = "wgs84" #epsg3413 for polar stereographic
-            bounding_box=("78,38,70,15" "77,37,69,14")
+            bounding_box=78.2@38.2@70.2@15.2,77.2@37.2@69.2@14.2
             centroid_x = "75"
             centroid_y = "20"
             minfloearea = "300"
@@ -57,8 +56,6 @@
             mkdir -p $h5_dir
         """
         
-    
-
     [[pullfetchimage]]
         script = """
             apptainer pull --force $project_dir/fetchdata.simg docker://brownccv/icefloetracker-fetchdata:main
@@ -72,18 +69,15 @@
     [[fetchdata<job_id>]]
         script = """
             i=${CYLC_TASK_PARAM_job_id}
+            bbox_array=( $(echo $bounding_box | sed -e 's/,/ /g') )
+            startdate_array=( $(echo $startdate | sed -e 's/,/ /g') )
+            enddate_array=( $(echo $enddate | sed -e 's/,/ /g') )
+            echo "bbox array = ${bbox_array[1]}"
+            echo "sdate array = ${startdate_array[1]}"
 
-            bounding_box_test=("78,38,70,15" "77,37,69,14")
-            bounding_box_env=${bounding_box[0]} #from cylc env var
-            echo "bounding_box = ${bounding_box[0]}" #from env directly
-            echo "bounding_box_env = ${bounding_box_env}" #from env unpacked
-            echo "bounding_box_test = ${bounding_box_test[0]}" #from this script block
-
-            startdate_env=$startdate
-            enddate_env=$enddate
-            
-            singularity exec --bind $fetchdata_dir/${CYLC_TASK_PARAM_job_id}:/tmp $project_dir/fetchdata.simg /usr/local/bin/fetchdata.sh -o /tmp -s ${startdate_env[$i]} -e ${enddate_env[$i]} -c $crs -b -b ${bounding_box_env}
+            singularity exec --bind $fetchdata_dir/${CYLC_TASK_PARAM_job_id}:/tmp $project_dir/fetchdata.simg /usr/local/bin/fetchdata.sh -o /tmp -s ${startdate_array[0]} -e ${enddate_array[0]} -c $crs -b ${bbox_array[0]}
         """
+        #
         platform = oscar
         execution time limit = PT1H
         [[[directives]]]

--- a/config/cylc_hpc/flow.cylc
+++ b/config/cylc_hpc/flow.cylc
@@ -1,5 +1,9 @@
 [scheduler]
     allow implicit tasks = True
+[task parameters]
+    # Update these variables with your run parameters
+    startdate = 2022-05-04, 2022-05-05, 2022-05-06
+    enddate = 2022-05-06, 2022-05-07, 2022-05-08
 [scheduling]
     cycling mode = integer
     initial cycle point = 1
@@ -11,8 +15,8 @@
     [[root]]
         [[[environment]]]
             # Update these variables with your run parameters
-            startdate = "2022-05-04"
-            enddate = "2022-05-06"
+            startdate = $startdate
+            enddate = $enddate
             crs = "wgs84" #epsg3413 for polar stereographic
             bounding_box = "78.186394 38.250605 70.749318 15.32373"
             centroid_x = "75"
@@ -46,7 +50,7 @@
         script = """
             apptainer build --force $project_dir/fetchdata.simg docker://brownccv/icefloetracker-fetchdata:main
         """
-    [[fetchdata]]
+    [[fetchdata<startdate>]]
         script = """
             singularity exec --bind $fetchdata_dir:/tmp $project_dir/fetchdata.simg /usr/local/bin/fetchdata.sh -o /tmp -s $startdate -e $enddate -c $crs $bounding_box
         """

--- a/config/cylc_hpc/flow.cylc
+++ b/config/cylc_hpc/flow.cylc
@@ -2,21 +2,23 @@
     allow implicit tasks = True
 [task parameters]
     # Update these variables with your run parameters
-    startdate = 2022-05-04, 2022-05-05, 2022-05-06
-    enddate = 2022-05-06, 2022-05-07, 2022-05-08
+    startdate = 2022-05-04, 2022-05-08
+    enddate = 2022-05-09, 2022-05-12
+    bbindex = 0..1
 [scheduling]
     cycling mode = integer
     initial cycle point = 1
     [[graph]]
         R1 = """
-            mkpaths<startdate> & pullfetchimage & pulljuliaimage => fetchdata<startdate,enddate> & soit<startdate,enddate> #=> landmask => preprocess => extractfeatures => tracking & exportH5
-             """
+            fetchdata<startdate,enddate,bbindex>
+            #mkpaths<startdate> & pullfetchimage & pulljuliaimage => fetchdata<startdate,enddate> & soit<startdate,enddate> #=> landmask => preprocess => extractfeatures => tracking & exportH5
+        """
 [runtime]
     [[root]]
         [[[environment]]]
             # Update these variables with your run parameters
             crs = "wgs84" #epsg3413 for polar stereographic
-            bounding_box = "78.186394 38.250605 70.749318 15.32373"
+            #bounding_box=("78,38,70,15" "77,37,69,14")
             centroid_x = "75"
             centroid_y = "20"
             minfloearea = "300"
@@ -45,14 +47,21 @@
             mkdir -p $tracker_dir
             mkdir -p $h5_dir
         """
+
     [[pullfetchimage]]
         script = """
             apptainer build --force $project_dir/fetchdata.simg docker://brownccv/icefloetracker-fetchdata:main
         """
-    [[fetchdata<startdate><enddate>]]
+
+    [[fetchdata<startdate,enddate,bbindex>]]
         script = """
-            singularity exec --bind $fetchdata_dir/${CYLC_TASK_PARAM_startdate}:/tmp $project_dir/fetchdata.simg /usr/local/bin/fetchdata.sh -o /tmp -s ${CYLC_TASK_PARAM_startdate} -e ${CYLC_TASK_PARAM_enddate} -c $crs $bounding_box
+            bounding_box=("78.1,38.2,70.3,15.4" "77.1,37.2,69.3,14.4")
+            i=${CYLC_TASK_PARAM_bbindex}
+            echo ${bounding_box[i]}
+
+            singularity exec --bind $fetchdata_dir/${CYLC_TASK_PARAM_startdate}:/tmp $project_dir/fetchdata.simg /usr/local/bin/fetchdata.sh -o /tmp -s ${CYLC_TASK_PARAM_startdate} -e ${CYLC_TASK_PARAM_enddate} -c $crs -b ${bounding_box[i]}
         """
+
     [[soit<startdate><enddate>]]
         script = """
             singularity exec --bind $soit_dir/${CYLC_TASK_PARAM_startdate}:/tmp $project_dir/fetchdata.simg python3 /usr/local/bin/pass_time_cylc.py --startdate ${CYLC_TASK_PARAM_startdate} --enddate ${CYLC_TASK_PARAM_enddate} --csvoutpath /tmp --centroid_x $centroid_x --centroid_y $centroid_y --SPACEUSER $SPACEUSER --SPACEPSWD $SPACEPSWD

--- a/config/cylc_hpc/flow.cylc
+++ b/config/cylc_hpc/flow.cylc
@@ -9,7 +9,8 @@
     initial cycle point = 1
     [[graph]]
         R1 = """
-            global_setup => mkpaths<job_id> => fetchdata<job_id> #& pullfetchimage & pulljuliaimage => fetchdata<job_id> #& soit<job_id> #=> landmask => preprocess => extractfeatures => tracking & exportH5
+            global_setup => soit<job_id>
+            #global_setup => mkpaths<job_id> => pullfetchimage & pulljuliaimage => fetchdata<job_id> & soit<job_id> => landmask<job_id> => preprocess<job_id> => extractfeatures<job_id> => tracking<job_id> & exportH5<job_id>
         """
 [runtime]
     [[root]]
@@ -17,14 +18,13 @@
             # Update these variables with your run parameters
             startdate = 2022-05-04,2022-05-08
             enddate = 2022-05-09,2022-05-12
-            crs = "wgs84" #epsg3413 for polar stereographic
+            crs = wgs84 #epsg3413 for polar stereographic
             bounding_box=78.2@38.2@70.2@15.2,77.2@37.2@69.2@14.2
-            centroid_x = "75"
-            centroid_y = "20"
-            minfloearea = "300"
-            maxfloearea = "90000"
+            centroid_x = 75,74
+            centroid_y = 20,19
+            minfloearea = 300
+            maxfloearea = 90000
             project_dir = "~/ice-floe-tracker-pipeline"
-            #input_data = (())
 
             # Recommend using these default paths for output
             julia_exec = "/usr/local/julia/bin/julia"
@@ -48,17 +48,18 @@
     
     [[mkpaths<job_id>]]
         script = """
-            mkdir -p $fetchdata_dir/${CYLC_TASK_PARAM_job_id}
-            mkdir -p $soit_dir/${CYLC_TASK_PARAM_job_id}
-            mkdir -p $landmask_dir
-            mkdir -p $preprocess_dir
-            mkdir -p $tracker_dir
-            mkdir -p $h5_dir
+            i=${CYLC_TASK_PARAM_job_id}
+            mkdir -p $fetchdata_dir/$i
+            mkdir -p $soit_dir/$i
+            mkdir -p $landmask_dir/$i
+            mkdir -p $preprocess_dir/$i
+            mkdir -p $tracker_dir/$i
+            mkdir -p $h5_dir/$i
         """
         
     [[pullfetchimage]]
         script = """
-            apptainer pull --force $project_dir/fetchdata.simg docker://brownccv/icefloetracker-fetchdata:main
+            apptainer pull --force $project_dir/fetchdata.simg docker://brownccv/icefloetracker-fetchdata:pr-70
         """
         platform = oscar
         execution time limit = PT1H
@@ -69,25 +70,29 @@
     [[fetchdata<job_id>]]
         script = """
             i=${CYLC_TASK_PARAM_job_id}
+
             bbox_array=( $(echo $bounding_box | sed -e 's/,/ /g') )
             startdate_array=( $(echo $startdate | sed -e 's/,/ /g') )
             enddate_array=( $(echo $enddate | sed -e 's/,/ /g') )
-            echo "bbox array = ${bbox_array[1]}"
-            echo "sdate array = ${startdate_array[1]}"
 
-            singularity exec --bind $fetchdata_dir/${CYLC_TASK_PARAM_job_id}:/tmp $project_dir/fetchdata.simg /usr/local/bin/fetchdata.sh -o /tmp -s ${startdate_array[0]} -e ${enddate_array[0]} -c $crs -b ${bbox_array[0]}
+            singularity exec --bind $fetchdata_dir/$i:/tmp $project_dir/fetchdata.simg /usr/local/bin/fetchdata.sh -o /tmp -s ${startdate_array[$i]} -e ${enddate_array[$i]} -c $crs -b ${bbox_array[$i]}
         """
-        #
         platform = oscar
         execution time limit = PT1H
         [[[directives]]]
             --mem = 12G
             --cpus-per-task = 8
-    
 
     [[soit<job_id>]]
         script = """
-            singularity exec --bind $soit_dir/${CYLC_TASK_PARAM_startdate}:/tmp $project_dir/fetchdata.simg python3 /usr/local/bin/pass_time_cylc.py --startdate ${CYLC_TASK_PARAM_startdate} --enddate ${CYLC_TASK_PARAM_enddate} --csvoutpath /tmp --centroid_x $centroid_x --centroid_y $centroid_y --SPACEUSER $SPACEUSER --SPACEPSWD $SPACEPSWD
+            i=${CYLC_TASK_PARAM_job_id}
+
+            startdate_array=( $(echo $startdate | sed -e 's/,/ /g') )
+            enddate_array=( $(echo $enddate | sed -e 's/,/ /g') )
+            centroid_x_array=( $(echo $centroid_x| sed -e 's/,/ /g') )
+            centroid_y_array=( $(echo $centroid_y | sed -e 's/,/ /g') )
+
+            singularity exec --bind $soit_dir/$i:/tmp $project_dir/fetchdata.simg python3 /usr/local/bin/pass_time_cylc.py --startdate ${startdate_array[$i]} --enddate ${enddate_array[$i]} --csvoutpath /tmp --centroid_x ${centroid_x_array[$i]} --centroid_y ${centroid_y_array[$i]} --SPACEUSER $SPACEUSER --SPACEPSWD $SPACEPSWD
         """
         platform = oscar
         execution time limit = PT1H
@@ -105,9 +110,11 @@
             --mem = 16G
             --cpus-per-task = 8
     
-    [[landmask]]
+    [[landmask<job_id>]]
         script = """
-            singularity exec --bind $landmask_dir:/tmp,$report_dir:/usr/local/bin/../report $project_dir/icefloetracker-julia.simg $julia_exec -t auto /usr/local/bin/ice-floe-tracker.jl landmask $fetchdata_dir /tmp
+            i=${CYLC_TASK_PARAM_job_id}
+
+            singularity exec --bind $landmask_dir/$i:/tmp,$report_dir:/usr/local/bin/../report $project_dir/icefloetracker-julia.simg $julia_exec -t auto /usr/local/bin/ice-floe-tracker.jl landmask $fetchdata_dir/$i /tmp
         """
         platform = oscar
         execution time limit = PT1H
@@ -115,19 +122,23 @@
             --mem = 20G
             --cpus-per-task = 16
     
-    [[preprocess]]
+    [[preprocess<job_id>]]
         script = """
-            singularity exec --bind $preprocess_dir:/tmp,$report_dir:/usr/local/bin/../report $project_dir/icefloetracker-julia.simg $julia_exec -t auto /usr/local/bin/ice-floe-tracker.jl preprocess -t $fetchdata_dir/truecolor -r $fetchdata_dir/reflectance -l $landmask_dir -p $soit_dir -o /tmp
+            i=${CYLC_TASK_PARAM_job_id}
+
+            singularity exec --bind $preprocess_dir/$i:/tmp,$report_dir:/usr/local/bin/../report $project_dir/icefloetracker-julia.simg $julia_exec -t auto /usr/local/bin/ice-floe-tracker.jl preprocess -t $fetchdata_dir/$i/truecolor -r $fetchdata_dir/$i/reflectance -l $landmask_dir/$i -p $soit_dir/$i -o /tmp
         """
         platform = oscar
         execution time limit = PT1H
         [[[directives]]]
-            --mem = 36G
+            --mem = 60G
             --cpus-per-task = 40
     
-    [[extractfeatures]]
+    [[extractfeatures<job_id>]]
         script = """
-            singularity exec --bind $preprocess_dir:/tmp,$report_dir:/usr/local/bin/../report $project_dir/icefloetracker-julia.simg $julia_exec -t auto /usr/local/bin/ice-floe-tracker.jl extractfeatures -i $preprocess_dir -o /tmp --minarea $minfloearea --maxarea $maxfloearea
+            i=${CYLC_TASK_PARAM_job_id}
+
+            singularity exec --bind $preprocess_dir/$i:/tmp,$report_dir:/usr/local/bin/../report $project_dir/icefloetracker-julia.simg $julia_exec -t auto /usr/local/bin/ice-floe-tracker.jl extractfeatures -i $preprocess_dir/$i -o /tmp --minarea $minfloearea --maxarea $maxfloearea
         """
         platform = oscar
         execution time limit = PT1H
@@ -135,9 +146,11 @@
             --mem = 20G
             --cpus-per-task = 8
     
-    [[tracking]]
+    [[tracking<job_id>]]
         script = """
-            singularity exec --bind $tracker_dir:/tmp,$report_dir:/usr/local/bin/../report $project_dir/icefloetracker-julia.simg $julia_exec -t auto /usr/local/bin/ice-floe-tracker.jl track --imgs $preprocess_dir --props $preprocess_dir --deltat $preprocess_dir --output /tmp
+            i=${CYLC_TASK_PARAM_job_id}
+
+            singularity exec --bind $tracker_dir/$i:/tmp,$report_dir:/usr/local/bin/../report $project_dir/icefloetracker-julia.simg $julia_exec -t auto /usr/local/bin/ice-floe-tracker.jl track --imgs $preprocess_dir/$i --props $preprocess_dir/$i --deltat $preprocess_dir/$i --output /tmp
         """
         platform = oscar
         execution time limit = PT1H
@@ -145,9 +158,11 @@
             --mem = 20G
             --cpus-per-task = 8
     
-    [[exportH5]]
+    [[exportH5<job_id>]]
         script = """
-            singularity exec --bind $preprocess_dir:/tmp,$report_dir:/usr/local/bin/../report $project_dir/icefloetracker-julia.simg $julia_exec -t auto /usr/local/bin/ice-floe-tracker.jl makeh5files --pathtosampleimg $fetchdata_dir/truecolor/$(ls $fetchdata_dir/truecolor | head -1) --resdir /tmp
+            i=${CYLC_TASK_PARAM_job_id}
+
+            singularity exec --bind $preprocess_dir/$i:/tmp,$report_dir:/usr/local/bin/../report $project_dir/icefloetracker-julia.simg $julia_exec -t auto /usr/local/bin/ice-floe-tracker.jl makeh5files --pathtosampleimg $fetchdata_dir/$i/truecolor/$(ls $fetchdata_dir/$i/truecolor | head -1) --resdir /tmp
         """
         platform = oscar
         execution time limit = PT1H

--- a/config/cylc_hpc/flow.cylc
+++ b/config/cylc_hpc/flow.cylc
@@ -9,14 +9,14 @@
     initial cycle point = 1
     [[graph]]
         R1 = """
-            mkpaths & pullfetchimage & pulljuliaimage => fetchdata & soit => landmask => preprocess => extractfeatures => tracking & exportH5
+            mkpaths & pullfetchimage & pulljuliaimage => fetchdata<startdate,enddate> & soit<startdate,enddate> #=> landmask => preprocess => extractfeatures => tracking & exportH5
              """
 [runtime]
     [[root]]
         [[[environment]]]
             # Update these variables with your run parameters
-            startdate = $startdate
-            enddate = $enddate
+            #startdate = $startdate
+            #enddate = $enddate
             crs = "wgs84" #epsg3413 for polar stereographic
             bounding_box = "78.186394 38.250605 70.749318 15.32373"
             centroid_x = "75"
@@ -50,11 +50,11 @@
         script = """
             apptainer build --force $project_dir/fetchdata.simg docker://brownccv/icefloetracker-fetchdata:main
         """
-    [[fetchdata<startdate>]]
+    [[fetchdata<startdate><enddate>]]
         script = """
             singularity exec --bind $fetchdata_dir:/tmp $project_dir/fetchdata.simg /usr/local/bin/fetchdata.sh -o /tmp -s $startdate -e $enddate -c $crs $bounding_box
         """
-    [[soit]]
+    [[soit<startdate><enddate>]]
         script = """
             singularity exec --bind $soit_dir:/tmp $project_dir/fetchdata.simg python3 /usr/local/bin/pass_time_cylc.py --startdate $startdate --enddate $enddate --csvoutpath /tmp --centroid_x $centroid_x --centroid_y $centroid_y --SPACEUSER $SPACEUSER --SPACEPSWD $SPACEPSWD
         """

--- a/config/cylc_hpc/flow.cylc
+++ b/config/cylc_hpc/flow.cylc
@@ -1,7 +1,7 @@
 [scheduler]
     allow implicit tasks = True
 [task parameters]
-    # Update these variables with your run parameters
+    # Update this variable to match the range of parameter sets
     job_id = 0..1
 
 [scheduling]

--- a/config/cylc_hpc/global.cylc
+++ b/config/cylc_hpc/global.cylc
@@ -4,3 +4,7 @@
         install target = localhost
         job runner = slurm
         retrieve job logs = True
+[install]
+    [[symlink dirs]]
+        [[[localhost]]]
+            run = ~/ice-floe-tracker-pipeline/workflow

--- a/config/cylc_local/flow.cylc
+++ b/config/cylc_local/flow.cylc
@@ -1,18 +1,20 @@
 [scheduler]
     allow implicit tasks = True
+[task parameters]
+    # Update these variables with your run parameters
+    startdate = 2022-05-04, 2022-05-05
+    enddate = 2022-05-07, 2022-05-08
 [scheduling]
     cycling mode = integer
     initial cycle point = 1
     [[graph]]
         R1 = """
-            mkpaths => fetchdata & soit => landmask => preprocess => extractfeatures => tracking & exportH5
+            mkpaths<startdate> & pullfetchimage & pulljuliaimage => fetchdata<startdate,enddate> & soit<startdate,enddate> # landmask => preprocess => extractfeatures => tracking & exportH5
              """
 [runtime]
     [[root]]
         [[[environment]]]
             # Update these variables with your run parameters
-            startdate = "2022-05-04"
-            enddate = "2022-05-06"
             crs = "wgs84" #epsg3413 for polar stereographic
             bounding_box = "78.186394 38.250605 70.749318 15.32373"
             centroid_x = "75"
@@ -32,22 +34,23 @@
             tracker_dir = $results_dir/"tracker"
             h5_dir = $preprocess_dir/"hdf5-files"
 
-    [[mkpaths]]
+    [[mkpaths<startdate>]]
         script = """
-            mkdir -p $soit_dir
+            mkdir -p $fetchdata_dir/${CYLC_TASK_PARAM_startdate}
+            mkdir -p $soit_dir/${CYLC_TASK_PARAM_startdate}
             mkdir -p $landmask_dir
             mkdir -p $preprocess_dir
             mkdir -p $tracker_dir
             mkdir -p $h5_dir
         """
         
-    [[fetchdata]]
+    [[fetchdata<startdate><enddate>]]
         script = """
-            docker run --mount type=bind,source=$fetchdata_dir,target=/tmp brownccv/icefloetracker-fetchdata:main /usr/local/bin/fetchdata.sh -o /tmp -s $startdate -e $enddate -c $crs $bounding_box
+            docker run --mount type=bind,source=$fetchdata_dir/${CYLC_TASK_PARAM_startdate},target=/tmp brownccv/icefloetracker-fetchdata:main /usr/local/bin/fetchdata.sh -o /tmp -s ${CYLC_TASK_PARAM_startdate} -e ${CYLC_TASK_PARAM_enddate} -c $crs $bounding_box
         """
-    [[soit]]
+    [[soit<startdate><enddate>]]
         script = """
-            docker run --env SPACEUSER --env SPACEPSWD --mount type=bind,source=$soit_dir,target=/tmp brownccv/icefloetracker-fetchdata:main python3 /usr/local/bin/pass_time_cylc.py --startdate $startdate --enddate $enddate --csvoutpath /tmp --centroid_x $centroid_x --centroid_y $centroid_y --SPACEUSER $SPACEUSER --SPACEPSWD $SPACEPSWD
+            docker run --env SPACEUSER --env SPACEPSWD --mount type=bind,source=$soit_dir/${CYLC_TASK_PARAM_startdate},target=/tmp brownccv/icefloetracker-fetchdata:main python3 /usr/local/bin/pass_time_cylc.py --startdate ${CYLC_TASK_PARAM_startdate} --enddate ${CYLC_TASK_PARAM_enddate} --csvoutpath /tmp --centroid_x $centroid_x --centroid_y $centroid_y --SPACEUSER $SPACEUSER --SPACEPSWD $SPACEPSWD
         """
     [[landmask]]
         script = """

--- a/config/cylc_local/flow.cylc
+++ b/config/cylc_local/flow.cylc
@@ -9,7 +9,7 @@
     initial cycle point = 1
     [[graph]]
         R1 = """
-            mkpaths<startdate> & pullfetchimage & pulljuliaimage => fetchdata<startdate,enddate> & soit<startdate,enddate> # landmask => preprocess => extractfeatures => tracking & exportH5
+            mkpaths<startdate> => fetchdata<startdate,enddate> & soit<startdate,enddate> # landmask => preprocess => extractfeatures => tracking & exportH5
              """
 [runtime]
     [[root]]

--- a/workflow/scripts/fetchdata.sh
+++ b/workflow/scripts/fetchdata.sh
@@ -51,7 +51,7 @@ ${BOLD}USAGE${NORMAL}
   $ ./${PROGRAM_NAME} [OPTIONS]
 
 ${BOLD}OPTIONS${NORMAL}
-  -b${TAB}${TAB}bounding box of interest in form "x1,y1,x2,y2"
+  -b${TAB}${TAB}bounding box of interest in form "x1@y1@x2@y2"
   ${TAB}${TAB}Note: for wgs84 input: x, y = lat, lon
   ${TAB}${TAB}      for epsg3413 input: x, y = easting, northing
   -c${TAB}${TAB}coordinate reference system: epsg3413, wgs84 (default: "wgs84")
@@ -62,7 +62,7 @@ ${BOLD}OPTIONS${NORMAL}
 
 ${BOLD}EXAMPLES${NORMAL}
   Download data from 2022-05-01 through today using lat/lon
-    $ ./${PROGRAM_NAME} -o data -s 2022-05-01 -b "81,-22,79,-12"
+    $ ./${PROGRAM_NAME} -o data -s 2022-05-01 -b "81@-22@79@-12"
 EOF
 }
 
@@ -73,16 +73,16 @@ convert_to_epsg3413() {
 
 get_topleft() {
   local bounding_box="${1}"
-  local x="$(echo ${bounding_box} | cut -d, -f1 )"
-  local y="$(echo ${bounding_box} | cut -d, -f2 )"
+  local x="$(echo ${bounding_box} | cut -d@ -f1 )"
+  local y="$(echo ${bounding_box} | cut -d@ -f2 )"
 
   echo "${x} ${y}"
 }
 
 get_bottomright() {
   local bounding_box="${1}"
-  local x="$(echo ${bounding_box} | cut -d, -f3 )"
-  local y="$(echo ${bounding_box} | cut -d, -f4 )"
+  local x="$(echo ${bounding_box} | cut -d@ -f3 )"
+  local y="$(echo ${bounding_box} | cut -d@ -f4 )"
 
   echo "${x} ${y}"
 }


### PR DESCRIPTION
This adds task parameters and cycling for start date and end date. The results also seem to be parameterized and flowing out of the container to results folders labeled by start date. Bounding box, however, is an illegal format for Cylc task paramaters, so we need to brainstorm on that.

TODO: 
- 

- [x ] Update the the hpc flow.cylc and test with start and end date cycling in Singualarity. 
- [ ] - Move all the environment variables to task parameters block? - not needed
- [x ]  Possibly update fetchdata.sh to accept a different bounding box format.