### PR TITLE
Feat add slurm

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The [Satellite Overpass Identification Tool](https://zenodo.org/record/6475619#.
 
 ## Cylc to run the pipeline
 
-Cylc is used to encode the entire pipeline from start to finish and relies on the command line scripts to automate the workflow. The `config/cylc_hpc/flow.cylc` file should be suitable for runs on HPC systems. The default pipeline is built to run on Brown's Oscar HPC and each task is submitted as it's own batch job. To run Cylc locally, the `config/cylc_local_flow.cylc` file is used.
+Cylc is used to encode the entire pipeline from start to finish and relies on the command line scripts to automate the workflow. The `config/cylc_hpc/flow.cylc` file should be suitable for runs on HPC systems. The default pipeline is built to run on Brown's Oscar HPC and each task is submitted as its own batch job. To run Cylc locally, the `config/cylc_local_flow.cylc` file is used.
 
 ### Running the Cylc pipeline on Oscar
 
@@ -53,6 +53,7 @@ Cylc is used to encode the entire pipeline from start to finish and relies on th
 
     ```
     cylc install -n <workflow-name> ./config/cylc_hpc
+    cylc validate <workflow-name>
     cylc play <workflow-name>
     cylc tui <workflow-name>
     ```
@@ -109,6 +110,7 @@ __Docker Desktop:__ Also make sure Docker Desktop client is running in the backg
 
    - [ ] `cylc install -n <your-workflow-name> ./config/cylc_local`
    - [ ] `cylc graph <workflow-name> #install graphviz locally`
+   - [ ] `cylc validate <workflow-name>`
    - [ ] `cylc play <workflow-name>`
    - [ ] `cylc tui <workflow-name>`
 
@@ -122,7 +124,7 @@ If you need to change parameters and re-run a workflow, first do:
     cylc clean <workflow-name>
     ```
    - [ ] Then, proceed to install, play, and open the TUI
-   - [ ] To rerun in one line: ```cylc stop --now <workflow-name> && cylc clean <workflow-name> && cylc install -n <workflow-name> ./config/cylc_hpc && cylc play <workflow-name> && cylc tui <workflow-name>```
+   - [ ] To rerun in one line: ```cylc stop --now <workflow-name> && cylc clean <workflow-name> && cylc install -n <workflow-name> ./config/cylc_hpc && cylc validate <workflow-name> && cylc play <workflow-name> && cylc tui <workflow-name>```
 
     __Note__ Error logs are available for each task:
     ```

--- a/README.md
+++ b/README.md
@@ -10,26 +10,21 @@ The [Satellite Overpass Identification Tool](https://zenodo.org/record/6475619#.
 
 ## Cylc to run the pipeline
 
-Cylc is used to encode the entire pipeline from start to finish and relies on the command line scripts to automate the workflow. The `config/cylc_hpc/flow.cylc` file should be suitable for runs on HPC systems. To run Cylc locally, the `config/cylc_local_flow.cylc` file is used.
+Cylc is used to encode the entire pipeline from start to finish and relies on the command line scripts to automate the workflow. The `config/cylc_hpc/flow.cylc` file should be suitable for runs on HPC systems. The default pipeline is built to run on Brown's Oscar HPC and each task is submitted as it's own batch job. To run Cylc locally, the `config/cylc_local_flow.cylc` file is used.
 
 ### Running the Cylc pipeline on Oscar
 
 1. - [ ] Connect to Oscar from VS Code
     * [use this guide](https://docs.ccv.brown.edu/oscar/connecting-to-oscar/remote-ide)
 
-2. Move to a compute node
-   - [ ] `interact -n 20 -t 24:00:00 -m 32g`
-    * this will start a compute session for 1 day with 32 GB memory and 20 cores
-    * see [here](https://docs.ccv.brown.edu/oscar/submitting-jobs/interact) for more options
-
-3. Build a virtual environment and install Cylc
+2. Build a virtual environment and install Cylc
    - [ ] `cd <your-project-path>/ice-floe-tracker-pipeline`
    - [ ] `conda env create -f ./config/ift-env.yaml`
    - [ ] `conda activate ift-env`
 
-4. Register an account with [space-track.org](https://www.space-track.org/) for SOIT
+3. Register an account with [space-track.org](https://www.space-track.org/) for SOIT
 
-5. Export SOIT username/password to environment variable
+4. Export SOIT username/password to environment variable
    - [ ] From your home directory `nano .bash_profile`
    - [ ] add `export HISTCONTROL=ignoreboth` to the bottom of your .bash_profile
         * this will ensure that your username/password are not stored in history
@@ -37,7 +32,7 @@ Cylc is used to encode the entire pipeline from start to finish and relies on th
    - [ ] ` export SPACEUSER=<firstname>_<lastname>@brown.edu`
    - [ ] ` export SPACEPSWD=<password>`
 
-6. Prepare the runtime environment 
+5. Prepare the runtime environment 
 
     Cylc will use software dependencies inside a Singularity container to fetch images and satellite times from external APIs. 
    - [ ] It is a good idea to reset the Singularity cache dir as specified [here](https://docs.ccv.brown.edu/oscar/singularity-containers/building-images)
@@ -127,6 +122,7 @@ If you need to change parameters and re-run a workflow, first do:
     cylc clean <workflow-name>
     ```
    - [ ] Then, proceed to install, play, and open the TUI
+   - [ ] To rerun in one line: ```cylc stop --now <workflow-name> && cylc clean <workflow-name> && cylc install -n <workflow-name> ./config/cylc_hpc && cylc play <workflow-name> && cylc tui <workflow-name>```
 
     __Note__ Error logs are available for each task:
     ```

--- a/config/cylc_hpc/flow.cylc
+++ b/config/cylc_hpc/flow.cylc
@@ -5,7 +5,7 @@
     initial cycle point = 1
     [[graph]]
         R1 = """
-            mkpaths & pullfetchimage & pulljuliaimage => fetchdata & soit => landmask => preprocess => extractfeatures => tracking & exportH5
+            global_setup => mkpaths & pullfetchimage #& pulljuliaimage => fetchdata & soit => landmask => preprocess => extractfeatures => tracking & exportH5
              """
 [runtime]
     [[root]]
@@ -33,59 +33,115 @@
             soit_dir = $results_dir/"soit"
             tracker_dir = $results_dir/"tracker"
             h5_dir = $preprocess_dir/"hdf5-files"
-            
+    
+    [[global_setup]]  
+        script = """
+            mkdir -p ~/.cylc
+            mkdir -p ~/.cylc/flow
+            cp $project_dir/config/cylc_hpc/global.cylc ~/.cylc/flow
+        """
+    
     [[mkpaths]]
-        platform = slurm_platform
+        script = """
+            mkdir -p $soit_dir
+            mkdir -p $landmask_dir
+            mkdir -p $preprocess_dir
+            mkdir -p $tracker_dir
+            mkdir -p $h5_dir
+        """
+        platform = oscar
         execution time limit = PT1H
         [[[directives]]]
             --mem = 4G
             --nodes = 6
-        script = """
-            srun mkdir -p $soit_dir
-            srun mkdir -p $landmask_dir
-            srun mkdir -p $preprocess_dir
-            srun mkdir -p $tracker_dir
-            srun mkdir -p $h5_dir
-        """
+    
     [[pullfetchimage]]
-        platform = slurm_platform
+        script = """
+            apptainer build --force $project_dir/fetchdata.simg docker://brownccv/icefloetracker-fetchdata:main
+        """
+        platform = oscar
         execution time limit = PT1H
         [[[directives]]]
-            --mem = 4G
-            --nodes = 6
-        script = """
-            srun apptainer build --force $project_dir/fetchdata.simg docker://brownccv/icefloetracker-fetchdata:main
-        """
+            --mem = 12G
+            --nodes = 8
+    
     [[fetchdata]]
         script = """
             singularity exec --bind $fetchdata_dir:/tmp $project_dir/fetchdata.simg /usr/local/bin/fetchdata.sh -o /tmp -s $startdate -e $enddate -c $crs $bounding_box
         """
+        platform = oscar
+        execution time limit = PT1H
+        [[[directives]]]
+            --mem = 12G
+            --nodes = 8
+    
     [[soit]]
         script = """
             singularity exec --bind $soit_dir:/tmp $project_dir/fetchdata.simg python3 /usr/local/bin/pass_time_cylc.py --startdate $startdate --enddate $enddate --csvoutpath /tmp --centroid_x $centroid_x --centroid_y $centroid_y --SPACEUSER $SPACEUSER --SPACEPSWD $SPACEPSWD
         """
+        platform = oscar
+        execution time limit = PT1H
+        [[[directives]]]
+            --mem = 12G
+            --nodes = 8
+    
     [[pulljuliaimage]]
         script = """
             apptainer build --force $project_dir/icefloetracker-julia.simg docker://brownccv/icefloetracker-julia:pr-45
         """
+        platform = oscar
+        execution time limit = PT1H
+        [[[directives]]]
+            --mem = 16G
+            --nodes = 8
+    
     [[landmask]]
         script = """
             singularity exec --bind $landmask_dir:/tmp,$report_dir:/usr/local/bin/../report $project_dir/icefloetracker-julia.simg $julia_exec -t auto /usr/local/bin/ice-floe-tracker.jl landmask $fetchdata_dir /tmp
         """
+        platform = oscar
+        execution time limit = PT1H
+        [[[directives]]]
+            --mem = 20G
+            --nodes = 8
+    
     [[preprocess]]
         script = """
             singularity exec --bind $preprocess_dir:/tmp,$report_dir:/usr/local/bin/../report $project_dir/icefloetracker-julia.simg $julia_exec -t auto /usr/local/bin/ice-floe-tracker.jl preprocess -t $fetchdata_dir/truecolor -r $fetchdata_dir/reflectance -l $landmask_dir -p $soit_dir -o /tmp
         """
+        platform = oscar
+        execution time limit = PT1H
+        [[[directives]]]
+            --mem = 36G
+            --nodes = 40
+    
     [[extractfeatures]]
         script = """
             singularity exec --bind $preprocess_dir:/tmp,$report_dir:/usr/local/bin/../report $project_dir/icefloetracker-julia.simg $julia_exec -t auto /usr/local/bin/ice-floe-tracker.jl extractfeatures -i $preprocess_dir -o /tmp --minarea $minfloearea --maxarea $maxfloearea
         """
+        platform = oscar
+        execution time limit = PT1H
+        [[[directives]]]
+            --mem = 20G
+            --nodes = 8
+    
     [[tracking]]
         script = """
             singularity exec --bind $tracker_dir:/tmp,$report_dir:/usr/local/bin/../report $project_dir/icefloetracker-julia.simg $julia_exec -t auto /usr/local/bin/ice-floe-tracker.jl track --imgs $preprocess_dir --props $preprocess_dir --deltat $preprocess_dir --output /tmp
         """
+        platform = oscar
+        execution time limit = PT1H
+        [[[directives]]]
+            --mem = 20G
+            --nodes = 8
+    
     [[exportH5]]
         script = """
             singularity exec --bind $preprocess_dir:/tmp,$report_dir:/usr/local/bin/../report $project_dir/icefloetracker-julia.simg $julia_exec -t auto /usr/local/bin/ice-floe-tracker.jl makeh5files --pathtosampleimg $fetchdata_dir/truecolor/$(ls $fetchdata_dir/truecolor | head -1) --resdir /tmp
         """
+        platform = oscar
+        execution time limit = PT1H
+        [[[directives]]]
+            --mem = 32G
+            --nodes = 24
         

--- a/config/cylc_hpc/flow.cylc
+++ b/config/cylc_hpc/flow.cylc
@@ -5,7 +5,7 @@
     initial cycle point = 1
     [[graph]]
         R1 = """
-            global_setup => mkpaths & pullfetchimage #& pulljuliaimage => fetchdata & soit => landmask => preprocess => extractfeatures => tracking & exportH5
+            global_setup => mkpaths & pullfetchimage & pulljuliaimage => fetchdata & soit => landmask => preprocess => extractfeatures => tracking & exportH5
              """
 [runtime]
     [[root]]

--- a/config/cylc_hpc/flow.cylc
+++ b/config/cylc_hpc/flow.cylc
@@ -35,16 +35,26 @@
             h5_dir = $preprocess_dir/"hdf5-files"
             
     [[mkpaths]]
+        platform = slurm_platform
+        execution time limit = PT1H
+        [[[directives]]]
+            --mem = 4G
+            --nodes = 6
         script = """
-            mkdir -p $soit_dir
-            mkdir -p $landmask_dir
-            mkdir -p $preprocess_dir
-            mkdir -p $tracker_dir
-            mkdir -p $h5_dir
+            srun mkdir -p $soit_dir
+            srun mkdir -p $landmask_dir
+            srun mkdir -p $preprocess_dir
+            srun mkdir -p $tracker_dir
+            srun mkdir -p $h5_dir
         """
     [[pullfetchimage]]
+        platform = slurm_platform
+        execution time limit = PT1H
+        [[[directives]]]
+            --mem = 4G
+            --nodes = 6
         script = """
-            apptainer build --force $project_dir/fetchdata.simg docker://brownccv/icefloetracker-fetchdata:main
+            srun apptainer build --force $project_dir/fetchdata.simg docker://brownccv/icefloetracker-fetchdata:main
         """
     [[fetchdata]]
         script = """

--- a/config/cylc_hpc/flow.cylc
+++ b/config/cylc_hpc/flow.cylc
@@ -14,7 +14,7 @@
             startdate = "2022-05-04"
             enddate = "2022-05-06"
             crs = "wgs84" #epsg3413 for polar stereographic
-            bounding_box = "78.186394 38.250605 70.749318 15.32373"
+            bounding_box = "78.186394,38.250605,70.749318,15.32373"
             centroid_x = "75"
             centroid_y = "20"
             minfloearea = "300"
@@ -53,27 +53,27 @@
         execution time limit = PT1H
         [[[directives]]]
             --mem = 4G
-            --nodes = 6
+            --cpus-per-task = 6
     
     [[pullfetchimage]]
         script = """
-            apptainer build --force $project_dir/fetchdata.simg docker://brownccv/icefloetracker-fetchdata:main
+            apptainer pull --force $project_dir/fetchdata.simg docker://brownccv/icefloetracker-fetchdata:main
         """
         platform = oscar
         execution time limit = PT1H
         [[[directives]]]
             --mem = 12G
-            --nodes = 8
+            --cpus-per-task = 8
     
     [[fetchdata]]
         script = """
-            singularity exec --bind $fetchdata_dir:/tmp $project_dir/fetchdata.simg /usr/local/bin/fetchdata.sh -o /tmp -s $startdate -e $enddate -c $crs $bounding_box
+            singularity exec --bind $fetchdata_dir:/tmp $project_dir/fetchdata.simg /usr/local/bin/fetchdata.sh -o /tmp -s $startdate -e $enddate -c $crs -b $bounding_box
         """
         platform = oscar
         execution time limit = PT1H
         [[[directives]]]
             --mem = 12G
-            --nodes = 8
+            --cpus-per-task = 8
     
     [[soit]]
         script = """
@@ -83,17 +83,17 @@
         execution time limit = PT1H
         [[[directives]]]
             --mem = 12G
-            --nodes = 8
+            --cpus-per-task = 8
     
     [[pulljuliaimage]]
         script = """
-            apptainer build --force $project_dir/icefloetracker-julia.simg docker://brownccv/icefloetracker-julia:pr-45
+            apptainer pull --force $project_dir/icefloetracker-julia.simg docker://brownccv/icefloetracker-julia:pr-45
         """
         platform = oscar
         execution time limit = PT1H
         [[[directives]]]
             --mem = 16G
-            --nodes = 8
+            --cpus-per-task = 8
     
     [[landmask]]
         script = """
@@ -103,7 +103,7 @@
         execution time limit = PT1H
         [[[directives]]]
             --mem = 20G
-            --nodes = 8
+            --cpus-per-task = 16
     
     [[preprocess]]
         script = """
@@ -113,7 +113,7 @@
         execution time limit = PT1H
         [[[directives]]]
             --mem = 36G
-            --nodes = 40
+            --cpus-per-task = 40
     
     [[extractfeatures]]
         script = """
@@ -123,7 +123,7 @@
         execution time limit = PT1H
         [[[directives]]]
             --mem = 20G
-            --nodes = 8
+            --cpus-per-task = 8
     
     [[tracking]]
         script = """
@@ -133,7 +133,7 @@
         execution time limit = PT1H
         [[[directives]]]
             --mem = 20G
-            --nodes = 8
+            --cpus-per-task = 8
     
     [[exportH5]]
         script = """
@@ -143,5 +143,5 @@
         execution time limit = PT1H
         [[[directives]]]
             --mem = 32G
-            --nodes = 24
+            --cpus-per-task = 24
         

--- a/config/cylc_hpc/flow.cylc
+++ b/config/cylc_hpc/flow.cylc
@@ -49,11 +49,7 @@
             mkdir -p $tracker_dir
             mkdir -p $h5_dir
         """
-        platform = oscar
-        execution time limit = PT1H
-        [[[directives]]]
-            --mem = 4G
-            --cpus-per-task = 6
+        
     
     [[pullfetchimage]]
         script = """

--- a/config/cylc_hpc/global.cylc
+++ b/config/cylc_hpc/global.cylc
@@ -1,0 +1,6 @@
+[platforms]
+    [[oscar]]
+        hosts = localhost
+        install target = localhost
+        job runner = slurm
+        retrieve job logs = True

--- a/config/cylc_local/flow.cylc
+++ b/config/cylc_local/flow.cylc
@@ -14,7 +14,7 @@
             startdate = "2022-05-04"
             enddate = "2022-05-06"
             crs = "wgs84" #epsg3413 for polar stereographic
-            bounding_box = "78.186394 38.250605 70.749318 15.32373"
+            bounding_box = "78.186394,38.250605,70.749318,15.32373"
             centroid_x = "75"
             centroid_y = "20"
             minfloearea = "300"
@@ -43,7 +43,7 @@
         
     [[fetchdata]]
         script = """
-            docker run --mount type=bind,source=$fetchdata_dir,target=/tmp brownccv/icefloetracker-fetchdata:main /usr/local/bin/fetchdata.sh -o /tmp -s $startdate -e $enddate -c $crs $bounding_box
+            docker run --mount type=bind,source=$fetchdata_dir,target=/tmp brownccv/icefloetracker-fetchdata:main /usr/local/bin/fetchdata.sh -o /tmp -s $startdate -e $enddate -c $crs -b $bounding_box
         """
     [[soit]]
         script = """


### PR DESCRIPTION
This PR add a global.cylc config file and adds slurm directives for each task. There is also a new task to copy over the global config from the repo to a location that Cylc is looking for. 

I tested a few directive configs and set the defaults to seemingly reasonable numbers of GB and cores for each task, but we could do more extensive testing in a new PR. 