### PR TITLE
Adjustments to SOIT implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ python3 /usr/local/bin/pass_time_cylc.py --startdate <YYYY-MM-DD> --enddate <YYY
    * csvoutpath must remain as `/tmp` to bind the Docker container output path with your desired local path
 
 **Note:** The `pass_time_cylc.py` script in this project can be adapted to include additional satellites available in the [space-track.org](https://www.space-track.org/) repository. If you have `numpy` and `skyfield` installed in a local `conda` environment, you can run `pass_time_cylc.py` from the directory where you installed the Ice Floe Tracker Pipeline:
-```python3 workflow/scripts/pass_time_cylc.py --startdate <YYYY-MM-DD> --enddate <YYYY-MM-DD> --csvoutpath /tmp --centroid_x <input_centroid_x> --centroid_y $<input_centroid_y> --SPACEUSER $SPACEUSER --SPACEPSWD $SPACEPSWD```
+```python3 workflow/scripts/pass_time_cylc.py --startdate <YYYY-MM-DD> --enddate <YYYY-MM-DD> --csvoutpath <save_directory> --centroid_x <input_centroid_x> --centroid_y <input_centroid_y> --SPACEUSER $SPACEUSER --SPACEPSWD $SPACEPSWD```
 
 ## Fetching data from NASA Worldview
 

--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@ To run SOIT manually :
    - [ ] ` export SPACEPSWD=<password>`
 3. Update inputs and run the following: 
 ```bash
-docker run --env SPACEUSER --env SPACEPSWD --mount type=bind,source=<your_desired_output_dir>,target=/tmp brownccv/ \
-icefloetracker-fetchdata:main \
+docker run --env SPACEUSER --env SPACEPSWD --mount type=bind,source=<your_desired_output_dir>,target=/tmp brownccv/icefloetracker-fetchdata:main \
 python3 /usr/local/bin/pass_time_cylc.py --startdate <YYYY-MM-DD> --enddate <YYYY-MM-DD> --csvoutpath /tmp --centroid_x <input_centroid_x> --centroid_y $<input_centroid_y> --SPACEUSER $SPACEUSER --SPACEPSWD $SPACEPSWD
 ```
    * be sure to replace `source`, `startdate`, `enddate`, `centroid_x`, and `centroid_y` with your desired inputs
    * csvoutpath must remain as `/tmp` to bind the Docker container output path with your desired local path
 
-**Note:** The `pass_time_cylc.py` script in this project can be adapted to include additional satellites available in the [space-track.org](https://www.space-track.org/) repository.
+**Note:** The `pass_time_cylc.py` script in this project can be adapted to include additional satellites available in the [space-track.org](https://www.space-track.org/) repository. If you have `numpy` and `skyfield` installed in a local `conda` environment, you can run `pass_time_cylc.py` from the directory where you installed the Ice Floe Tracker Pipeline:
+```python3 workflow/scripts/pass_time_cylc.py --startdate <YYYY-MM-DD> --enddate <YYYY-MM-DD> --csvoutpath /tmp --centroid_x <input_centroid_x> --centroid_y $<input_centroid_y> --SPACEUSER $SPACEUSER --SPACEPSWD $SPACEPSWD```
 
 ## Fetching data from NASA Worldview
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To run SOIT manually :
 3. Update inputs and run the following: 
 ```bash
 docker run --env SPACEUSER --env SPACEPSWD --mount type=bind,source=<your_desired_output_dir>,target=/tmp brownccv/icefloetracker-fetchdata:main \
-python3 /usr/local/bin/pass_time_cylc.py --startdate <YYYY-MM-DD> --enddate <YYYY-MM-DD> --csvoutpath /tmp --centroid_x <input_centroid_x> --centroid_y $<input_centroid_y> --SPACEUSER $SPACEUSER --SPACEPSWD $SPACEPSWD
+python3 /usr/local/bin/pass_time_cylc.py --startdate <YYYY-MM-DD> --enddate <YYYY-MM-DD> --csvoutpath /tmp --centroid_lat <input_centroid_lat> --centroid_lon <input_centroid_lon> --SPACEUSER $SPACEUSER --SPACEPSWD $SPACEPSWD
 ```
    * be sure to replace `source`, `startdate`, `enddate`, `centroid_lat`, and `centroid_lon` with your desired inputs
    * csvoutpath must remain as `/tmp` to bind the Docker container output path with your desired local path

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To run SOIT manually :
 docker run --env SPACEUSER --env SPACEPSWD --mount type=bind,source=<your_desired_output_dir>,target=/tmp brownccv/icefloetracker-fetchdata:main \
 python3 /usr/local/bin/pass_time_cylc.py --startdate <YYYY-MM-DD> --enddate <YYYY-MM-DD> --csvoutpath /tmp --centroid_x <input_centroid_x> --centroid_y $<input_centroid_y> --SPACEUSER $SPACEUSER --SPACEPSWD $SPACEPSWD
 ```
-   * be sure to replace `source`, `startdate`, `enddate`, `centroid_x`, and `centroid_y` with your desired inputs
+   * be sure to replace `source`, `startdate`, `enddate`, `centroid_lat`, and `centroid_lon` with your desired inputs
    * csvoutpath must remain as `/tmp` to bind the Docker container output path with your desired local path
 
 **Note:** The `pass_time_cylc.py` script in this project can be adapted to include additional satellites available in the [space-track.org](https://www.space-track.org/) repository. If you have `numpy` and `skyfield` installed in a local `conda` environment, you can run `pass_time_cylc.py` from the directory where you installed the Ice Floe Tracker Pipeline:

--- a/workflow/scripts/pass_time_cylc.py
+++ b/workflow/scripts/pass_time_cylc.py
@@ -41,20 +41,18 @@ class MyError(Exception):
 
 
 def get_passtimes(
-    startdate, enddate, csvoutpath, centroid_x, centroid_y, SPACEUSER, SPACEPSWD
+    startdate, enddate, csvoutpath, centroid_lat, centroid_lon, SPACEUSER, SPACEPSWD
 ):
-    centroidx = centroid_x
-    centroidy = centroid_y
     configUsr = SPACEUSER
     configPwd = SPACEPSWD
     siteCred = {"identity": configUsr, "password": configPwd}
     end_date = datetime.datetime.strptime(enddate, "%Y-%m-%d").strftime("%m-%d-%Y").split("-")
     start_date = datetime.datetime.strptime(startdate, "%Y-%m-%d").strftime("%m-%d-%Y").split("-")
-    lat = int(centroidx)
-    long = int(centroidy)
+    lat = float(centroid_lat)
+    lon = float(centroid_lon)
     print(f"Outpath {csvoutpath}")
     print(f"Timeframe starts on {start_date}, and ends on {end_date}")
-    print(f"Centroid (x, y): ({centroidx}, {centroidy})")
+    print(f"Cooridinates (x, y): ({centroid_lat}, {centroid_lon})")
 
     end_date = getNextDay(end_date)
 
@@ -100,7 +98,7 @@ def get_passtimes(
     ts = load.timescale()
 
     # Specify area of interest.
-    aoi = wgs84.latlon(lat, long)
+    aoi = wgs84.latlon(lat, lon)
 
     # Define today and tomorrow.
     today = start_date
@@ -375,7 +373,7 @@ def get_passtimes(
             today = getNextDay(today)
             tomorrow = getNextDay(today)
 
-    csvwrite(start_date, end_date, lat, long, rows, csvoutpath)
+    csvwrite(start_date, end_date, lat, lon, rows, csvoutpath)
 
 
 # Write CSV of all pass information.
@@ -459,17 +457,17 @@ def main():
         help="End date in format YYYY-MM-DD",
     )
     parser.add_argument(
-        "--centroid_x",
-        "-x",
-        metavar="centroid_x",
+        "--centroid_lat",
+        "-lat",
+        metavar="centroid_lat",
         type=str,
-        help="x-coordinate of bounding box centroid",
+        help="latitude of bounding box centroid",
     )
     parser.add_argument(
-        "--centroid_y",
-        "-y",
+        "--centroid_lon",
+        "-lon",
         type=str,
-        help="y-coordinate of bounding box centroid",
+        help="longitude of bounding box centroid",
     )
     parser.add_argument(
         "--csvoutpath",

--- a/workflow/scripts/pass_time_cylc.py
+++ b/workflow/scripts/pass_time_cylc.py
@@ -52,7 +52,7 @@ def get_passtimes(
     lon = float(centroid_lon)
     print(f"Outpath {csvoutpath}")
     print(f"Timeframe starts on {start_date}, and ends on {end_date}")
-    print(f"Cooridinates (x, y): ({centroid_lat}, {centroid_lon})")
+    print(f"Coordinates (x, y): ({centroid_lat}, {centroid_lon})")
 
     end_date = getNextDay(end_date)
 

--- a/workflow/scripts/pass_time_cylc.py
+++ b/workflow/scripts/pass_time_cylc.py
@@ -466,6 +466,7 @@ def main():
     parser.add_argument(
         "--centroid_lon",
         "-lon",
+        metavar="centroid_lon",
         type=str,
         help="longitude of bounding box centroid",
     )


### PR DESCRIPTION
I came across some issues trying to follow the steps in the README for running things locally. Along with an issue in the README with an extra space in a pathname, I was reminded of the confusing naming convention for x/y and lat/lon and the issue that SOIT is forcing lat/lon to be integers. I couldn't find any reason that lat/lon should be integers -- all it does is add more error to the calculations -- so I changed "int" to "float" and I changed the references to x and y to what they really meant. 