### PR TITLE
fix: update args to tracker cli function

### DIFF
--- a/config/cylc_hpc/flow_template_hpc.j2
+++ b/config/cylc_hpc/flow_template_hpc.j2
@@ -126,7 +126,7 @@
             i=${CYLC_TASK_PARAM_param_set}
             location_array=( $(echo $location | sed -e 's/,/ /g') )
 
-            apptainer exec --env JULIA_DEPOT_PATH=$HOME/.julia:/opt/julia --bind $results_dir/${location_array[$i]}/landmasks:/tmp,$report_dir:/usr/local/bin/../report $project_dir/icefloetracker-julia.simg $julia_exec -t auto /usr/local/bin/ice-floe-tracker.jl landmask $fetchdata_dir/${location_array[$i]} /tmp
+            apptainer exec --env JULIA_DEPOT_PATH=$HOME/.julia:/opt/julia --bind $results_dir/${location_array[$i]}/landmasks:/tmp,$report_dir:/usr/local/report $project_dir/icefloetracker-julia.simg $julia_exec -t auto /usr/local/bin/ice-floe-tracker.jl landmask $fetchdata_dir/${location_array[$i]} /tmp
         """
         platform = oscar
         execution time limit = PT1H
@@ -142,7 +142,7 @@
             i=${CYLC_TASK_PARAM_param_set}
             location_array=( $(echo $location | sed -e 's/,/ /g') )
 
-            apptainer exec --env JULIA_DEPOT_PATH=$HOME/.julia:/opt/julia --bind $results_dir/${location_array[$i]}/preprocess:/tmp,$report_dir:/usr/local/bin/../report $project_dir/icefloetracker-julia.simg $julia_exec -t auto /usr/local/bin/ice-floe-tracker.jl preprocess -t $fetchdata_dir/${location_array[$i]}/truecolor -r $fetchdata_dir/${location_array[$i]}/reflectance -l $results_dir/${location_array[$i]}/landmasks -p $results_dir/${location_array[$i]}/soit -o /tmp
+            apptainer exec --env JULIA_DEPOT_PATH=$HOME/.julia:/opt/julia --bind $results_dir/${location_array[$i]}/preprocess:/tmp,$report_dir:/usr/local/report $project_dir/icefloetracker-julia.simg $julia_exec -t auto /usr/local/bin/ice-floe-tracker.jl preprocess -t $fetchdata_dir/${location_array[$i]}/truecolor -r $fetchdata_dir/${location_array[$i]}/reflectance -l $results_dir/${location_array[$i]}/landmasks -p $results_dir/${location_array[$i]}/soit -o /tmp
         """
         platform = oscar
         execution time limit = PT1H
@@ -159,15 +159,15 @@
             location_array=( $(echo $location | sed -e 's/,/ /g') )
             preprocess_dir=$results_dir/${location_array[$i]}/preprocess
 
-            apptainer exec --env JULIA_DEPOT_PATH=$HOME/.julia:/opt/julia --bind $preprocess_dir:/tmp,$report_dir:/usr/local/bin/../report $project_dir/icefloetracker-julia.simg $julia_exec -t auto /usr/local/bin/ice-floe-tracker.jl extractfeatures -i $preprocess_dir -o /tmp --minarea $minfloearea --maxarea $maxfloearea
+            apptainer exec --env JULIA_DEPOT_PATH=$HOME/.julia:/opt/julia --bind $preprocess_dir:/tmp,$report_dir:/usr/local/report $project_dir/icefloetracker-julia.simg $julia_exec -t auto /usr/local/bin/ice-floe-tracker.jl extractfeatures -i $preprocess_dir -o /tmp --minarea $minfloearea --maxarea $maxfloearea
         """
         platform = oscar
         execution time limit = PT1H
         submission retry delays = 2*PT30S
         execution retry delays = PT6S
         [[[directives]]]
-            --mem = 20G
-            --cpus-per-task = 1
+            --mem = 18G
+            --cpus-per-task = 2
     
     [[tracking<param_set>]]
         # Pair and track identified floes across days
@@ -175,8 +175,9 @@
             i=${CYLC_TASK_PARAM_param_set}
             location_array=( $(echo $location | sed -e 's/,/ /g') )
             preprocess_dir=$results_dir/${location_array[$i]}/preprocess
+            sample_img=$fetchdata_dir/${location_array[$i]}/truecolor/$(ls $fetchdata_dir/${location_array[$i]}/truecolor | head -1)
 
-            apptainer exec --env JULIA_DEPOT_PATH=$HOME/.julia:/opt/julia --bind $results_dir/${location_array[$i]}/"tracker":/tmp,$report_dir:/usr/local/bin/../report $project_dir/icefloetracker-julia.simg $julia_exec -t auto /usr/local/bin/ice-floe-tracker.jl track --imgs $preprocess_dir --props $preprocess_dir --deltat $preprocess_dir --output /tmp
+            apptainer exec --env JULIA_DEPOT_PATH=$HOME/.julia:/opt/julia --bind $results_dir/${location_array[$i]}/"tracker":/tmp,$report_dir:/usr/local/report $project_dir/icefloetracker-julia.simg $julia_exec -t auto /usr/local/bin/ice-floe-tracker.jl track --imgs $preprocess_dir --props $preprocess_dir --passtimes $preprocess_dir --latlon $sample_img --output /tmp
         """
         platform = oscar
         execution time limit = PT1H
@@ -191,13 +192,14 @@
         script = """
             i=${CYLC_TASK_PARAM_param_set}
             location_array=( $(echo $location | sed -e 's/,/ /g') )
+            sample_img=$fetchdata_dir/${location_array[$i]}/truecolor/$(ls $fetchdata_dir/${location_array[$i]}/truecolor | head -1)
 
-            apptainer exec --env JULIA_DEPOT_PATH=$HOME/.julia:/opt/julia --bind $results_dir/${location_array[$i]}/preprocess:/tmp,$report_dir:/usr/local/bin/../report $project_dir/icefloetracker-julia.simg $julia_exec -t auto /usr/local/bin/ice-floe-tracker.jl makeh5files --pathtosampleimg $fetchdata_dir/${location_array[$i]}/truecolor/$(ls $fetchdata_dir/${location_array[$i]}/truecolor | head -1) --resdir /tmp
+            apptainer exec --env JULIA_DEPOT_PATH=$HOME/.julia:/opt/julia --bind $results_dir/${location_array[$i]}/preprocess:/tmp,$report_dir:/usr/local/report $project_dir/icefloetracker-julia.simg $julia_exec -t auto /usr/local/bin/ice-floe-tracker.jl makeh5files --pathtosampleimg $sample_img --resdir /tmp
         """
         platform = oscar
         execution time limit = PT1H
         submission retry delays = 2*PT30S
         execution retry delays = 2*PT6S
         [[[directives]]]
-            --mem = 32G
-            --cpus-per-task = 1
+            --mem = 18G
+            --cpus-per-task = 2


### PR DESCRIPTION
This PR updates the tracker cli args in the Cylc HPC script. This is related to the updates from #91, and closes #103! I also cleaned up some superfluous paths.