### PR TITLE
chore: add Git attributes for LFS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+*.png filter=lfs diff=lfs merge=lfs -text
+*.tiff filter=lfs diff=lfs merge=lfs -text
+*.dat filter=lfs diff=lfs merge=lfs -text
+*.jls filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
This will reduce the overall size of the repo. More in #119

I'll probably do this for the IFT repo as well.

Selected .png, .tiff, .dat, and .jls file types to be managed by Git LFS. These are the data file extensions used for testing. See how this is handled in the .gitattributes file.

After merging this PR, these file types will be handled by Git LFS. This means that when these files are added, committed, and pushed, they will be stored on a remote server, and text pointers will be stored in the Git repository.

Please note that to work with these large files, contributors will need to have Git LFS installed on their local machine.