### PR TITLE
add workflow dispatch param to action

### DIFF
--- a/.github/workflows/build-docker-julia.yml
+++ b/.github/workflows/build-docker-julia.yml
@@ -10,6 +10,7 @@ on:
   pull_request:  
     branches:
       - 'main'
+  workflow_dispatch:
 
 env:
   REGISTRY: hub.docker.com


### PR DESCRIPTION
This is needed to be able to trigger this workflow from the source repo, IceFloeTracker, with another action. See https://github.com/WilhelmusLab/IceFloeTracker.jl/pull/370 and https://github.com/WilhelmusLab/IceFloeTracker.jl/pull/368