### PR TITLE
Add choose_dtype function and update test suite

### DIFF
--- a/src/h5.jl
+++ b/src/h5.jl
@@ -25,7 +25,7 @@ Choose the appropriate unsigned integer type based on a maximum value.
 """
 function choose_dtype(mx)
     types = [UInt8, UInt16, UInt32]
-    for t in enumerate(types)
+    for (i, t) in enumerate(types)
         b = 2^(2^(2 + i)) - 1
         if mx <= b
             return t

--- a/src/h5.jl
+++ b/src/h5.jl
@@ -25,8 +25,8 @@ Choose the appropriate unsigned integer type based on a maximum value.
 """
 function choose_dtype(mx)
     types = [UInt8, UInt16, UInt32]
-    bounds = [2^(2^(2+i)) - 1 for (i, _) in enumerate(types)]
-    for (b, t) in zip(bounds, types)
+    for t in enumerate(types)
+        b = 2^(2^(2 + i)) - 1
         if mx <= b
             return t
         end

--- a/src/h5.jl
+++ b/src/h5.jl
@@ -24,8 +24,8 @@ Choose the appropriate unsigned integer type based on a maximum value.
       * `UInt32` if `mx` is less than or equal to 4294967295.
 """
 function choose_dtype(mx)
-    bounds = [2^(2^i) - 1 for i in 3:5]
     types = [UInt8, UInt16, UInt32]
+    bounds = [2^(2^(2+i)) - 1 for (i, _) in enumerate(types)]
     for (b, t) in zip(bounds, types)
         if mx <= b
             return t

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using IFTPipeline
 using IFTPipeline: load_imgs, sharpen, sharpen_gray, loadimg
-using IFTPipeline: HDF5, h5open, attrs
+using IFTPipeline: HDF5, h5open, attrs, choose_dtype
 using .IceFloeTracker: DataFrames, save, Gray, create_cloudmask, deserialize, serialize, float64, load, imrotate, loadimg, RGB, DataFrame, nrow, rename!, Dates, Not, select!, getlatlon
 using ArgParse: @add_arg_table!, ArgParseSettings, add_arg_group!, parse_args
 using DelimitedFiles

--- a/test/test-h5.jl
+++ b/test/test-h5.jl
@@ -49,19 +49,16 @@ h5path = joinpath(resdir, "hdf5-files", "20220914T1244.aqua.labeled_image.250m.h
 
     # groups
     testlisteq(keys(fid), ["floe_properties", "index"])
-    testlisteq(keys(fid["index"]), ["latitude", "longitude", "time", "x", "y"])
+    keys_index = [k for k in keys(fid["index"]) if k ∉ ["latitude", "longitude"]]
+    testlisteq(keys_index, ["time", "x", "y"])
     testlisteq(keys(fid["floe_properties"]), ["column_names", "labeled_image", "properties"])
 
     # check index group datasets
     g = fid["index"]
-    lat = read(g["latitude"])
-    lon = read(g["longitude"])
     t = read(g["time"])
     x = read(g["x"])
     y = read(g["y"])
 
-    @test lat == latlondata["latitude"]
-    @test lon == latlondata["longitude"]
     @test t == ptsunix[1]
     @test x == latlondata["X"]
     @test y == latlondata["Y"]
@@ -74,9 +71,13 @@ h5path = joinpath(resdir, "hdf5-files", "20220914T1244.aqua.labeled_image.250m.h
 
     testlisteq(colnames, ["area", "convex_area", "major_axis_length", "minor_axis_length", "orientation", "perimeter", "latitude", "longitude", "x", "y"])
 
-    @test typeof(lb) == Matrix{Int64}
+    @test typeof(lb) == Matrix{UInt8}
     @test typeof(props) == Matrix{Float64}
     close(fid)
+
+    @test choose_dtype(100) == UInt8
+    @test choose_dtype(300) == UInt16
+    @test choose_dtype(70_000) == UInt32
 end
 
 # clean up


### PR DESCRIPTION
This pull request adds the `choose_dtype` function, which determines the appropriate unsigned integer type based on a maximum value for storing the labeled image in hdf5. It also updates the test suite droping tests for lat/lon as these won't be included in the h5 archives.