### PR TITLE
Fix SOIT

### DIFF
--- a/.github/workflows/test-soit.yml
+++ b/.github/workflows/test-soit.yml
@@ -1,0 +1,26 @@
+name: Test SOIT
+
+on:
+    push:
+        branches:
+            - main
+    pull_request:
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v2
+
+            - name: Set up Python
+              uses: actions/setup-python@v2 with:
+                  python-version: 3.9
+
+            - name: Install dependencies
+              run: pip install -r requirements.txt
+
+            - name: Run SOIT
+              run: |
+                python workflow/script/pass_time_cylc.py -u ${{ secrets.SPACEUSER }} -p ${{ secrets.SPACEPSWD }} --startdate 2013-03-31 --enddate 2013-05-01 --lat 76.0015 --lon -18.4315 --csvoutpath .

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ df.head()
 
 ```
 
-### Simple visualization of a segmented image
+### Simple visualization of a segmented image 
 ```python
 import numpy as np
 import matplotlib.pyplot as plt

--- a/config/cylc_hpc/flow_template_hpc.j2
+++ b/config/cylc_hpc/flow_template_hpc.j2
@@ -96,7 +96,7 @@
             centroid_lat_array=( $(echo $centroid_lat| sed -e 's/,/ /g') )
             centroid_lon_array=( $(echo $centroid_lon | sed -e 's/,/ /g') )
 
-            apptainer exec --bind $results_dir/${location_array[$i]}/soit:/tmp $project_dir/fetchdata.simg python3 /usr/local/bin/pass_time_cylc.py --startdate ${startdate_array[$i]} --enddate ${enddate_array[$i]} --csvoutpath /tmp --centroid_lat ${centroid_lat_array[$i]} --centroid_lon ${centroid_lon_array[$i]} --SPACEUSER $SPACEUSER --SPACEPSWD $SPACEPSWD
+            apptainer exec --bind $results_dir/${location_array[$i]}/soit:/tmp $project_dir/fetchdata.simg python3 /usr/local/bin/pass_time_cylc.py --startdate ${startdate_array[$i]} --enddate ${enddate_array[$i]} --csvoutpath /tmp --centroid-lat ${centroid_lat_array[$i]} --centroid-lon ${centroid_lon_array[$i]} --SPACEUSER $SPACEUSER --SPACEPSWD $SPACEPSWD
         """
         platform = oscar
         execution time limit = PT1H

--- a/config/cylc_hpc/flow_template_hpc.j2
+++ b/config/cylc_hpc/flow_template_hpc.j2
@@ -8,7 +8,7 @@
     initial cycle point = PT1M #creates a datetime one minute from system time in UTC
     [[graph]]
         R1 = global_setup  => mkpaths<param_set> => pullfetchimage & pulljuliaimage => fetchdata<param_set> & soit<param_set> => landmask<param_set> => preprocess<param_set> => extractfeatures<param_set> => tracking<param_set> & exportH5<param_set>
-        
+
 [runtime]
     [[root]]
         [[[environment]]]
@@ -17,7 +17,7 @@
             startdate = {{ startdate }}
             enddate = {{ enddate }}
             crs = {{ crs }} # epsg3413 for polar stereographic: left_x@top_y@right_x@lower_y
-                             # wgs84 for lat/lon: top_left_lat@top_left_lon@lower_right_lat@lower_right_lon            
+                             # wgs84 for lat/lon: top_left_lat@top_left_lon@lower_right_lat@lower_right_lon
             bounding_box = {{ bounding_box }}
             centroid_lat = {{ center_lat }}
             centroid_lon = {{ center_lon }}
@@ -33,8 +33,8 @@
             fetchdata_dir = $project_dir/"resources"/$t
             truecolor_dir = $fetchdata_dir/"truecolor"
             falsecolor_dir = $fetchdata_dir/"falsecolor"
-            
-    [[global_setup]]  
+
+    [[global_setup]]
         script = """
             mkdir -p ~/.cylc
             mkdir -p ~/.cylc/flow
@@ -105,10 +105,10 @@
         [[[directives]]]
             --mem = 12G
             --cpus-per-task = 4
-    
+
     [[pulljuliaimage]]
         # Pull the latest Docker image containing Julia IceFloeTracker software
-        # apptainer will check the image layers and only re-download if necessary 
+        # apptainer will check the image layers and only re-download if necessary
         script = """
             apptainer pull --force $project_dir/icefloetracker-julia.simg docker://brownccv/icefloetracker-julia:main
         """
@@ -135,7 +135,7 @@
         [[[directives]]]
             --mem-per-cpu = 4G
             --cpus-per-task = 8
-    
+
     [[preprocess<param_set>]]
         # Preprocess the satellite imagery and convert to binary
         script = """
@@ -151,7 +151,7 @@
         [[[directives]]]
             --mem-per-cpu = 12G
             --cpus-per-task = 20
-    
+
     [[extractfeatures<param_set>]]
         # Identify floes and extract floe metrics from binary processed images
         script = """
@@ -168,7 +168,7 @@
         [[[directives]]]
             --mem = 18G
             --cpus-per-task = 2
-    
+
     [[tracking<param_set>]]
         # Pair and track identified floes across days
         script = """
@@ -186,7 +186,7 @@
         [[[directives]]]
             --mem = 20G
             --cpus-per-task = 1
-    
+
     [[exportH5<param_set>]]
         # Package intermediate and final outputs into HDF5 files
         script = """

--- a/config/cylc_local/flow_template_local.j2
+++ b/config/cylc_local/flow_template_local.j2
@@ -16,7 +16,7 @@
             startdate = {{ startdate }}
             enddate = {{ enddate }}
             crs = {{ crs }} # epsg3413 for polar stereographic: left_x@top_y@right_x@lower_y
-                             # wgs84 for lat/lon: top_left_lat@top_left_lon@lower_right_lat@lower_right_lon            
+                             # wgs84 for lat/lon: top_left_lat@top_left_lon@lower_right_lat@lower_right_lon
             bounding_box = {{ bounding_box }}
             centroid_x = {{ centroid_x }}
             centroid_y = {{ centroid_y }}
@@ -47,7 +47,7 @@
             mkdir -p $res/tracker
             mkdir -p $res/preprocess/hdf5-files
         """
-        
+
     [[fetchdata<param_set>]]
         # Convert param lists to indexable bash arrays and fetch falsecolor, truecolor, and landmask for each location
         script = """
@@ -56,7 +56,7 @@
             location_array=( $(echo $location | sed -e 's/,/ /g') )
             startdate_array=( $(echo $startdate | sed -e 's/,/ /g') )
             enddate_array=( $(echo $enddate | sed -e 's/,/ /g') )
-            
+
             docker run --mount type=bind,source=$fetchdata_dir/${location_array[$i]},target=/tmp --mount type=bind,source=$report_dir,target=/usr/local/bin/../report brownccv/icefloetracker-fetchdata:main /usr/local/bin/fetchdata.sh -o /tmp -s ${startdate_array[$i]} -e ${enddate_array[$i]} -c $crs -b ${bbox_array[$i]}
         """
     [[soit<param_set>]]
@@ -69,7 +69,7 @@
             centroid_x_array=( $(echo $centroid_x| sed -e 's/,/ /g') )
             centroid_y_array=( $(echo $centroid_y | sed -e 's/,/ /g') )
 
-            docker run --env SPACEUSER --env SPACEPSWD --mount type=bind,source=$results_dir/${location_array[$i]}/soit,target=/tmp --mount type=bind,source=$report_dir,target=/usr/local/bin/../report brownccv/icefloetracker-fetchdata:main python3 /usr/local/bin/pass_time_cylc.py --startdate ${startdate_array[$i]} --enddate ${enddate_array[$i]} --csvoutpath /tmp --centroid_x ${centroid_x_array[$i]} --centroid_y ${centroid_y_array[$i]} --SPACEUSER $SPACEUSER --SPACEPSWD $SPACEPSWD
+            docker run --env SPACEUSER --env SPACEPSWD --mount type=bind,source=$results_dir/${location_array[$i]}/soit,target=/tmp --mount type=bind,source=$report_dir,target=/usr/local/bin/../report brownccv/icefloetracker-fetchdata:main python3 /usr/local/bin/pass_time_cylc.py --startdate ${startdate_array[$i]} --enddate ${enddate_array[$i]} --csvoutpath /tmp --centroid-lon ${centroid_x_array[$i]} --centroid-lat ${centroid_y_array[$i]} --SPACEUSER $SPACEUSER --SPACEPSWD $SPACEPSWD
         """
 
     [[landmask<param_set>]]
@@ -90,7 +90,7 @@
             location_array=( $(echo $location | sed -e 's/,/ /g') )
 
             docker run --mount type=bind,source=$results_dir/${location_array[$i]}/preprocess,target=/tmp \
-            --mount 
+            --mount
 type=bind,source=$report_dir,target=/usr/local/bin/../report \
             brownccv/icefloetracker-julia:main $julia_exec -t auto /usr/local/bin/ice-floe-tracker.jl preprocess -t $fetchdata_dir/${location_array[$i]}/truecolor -r $fetchdata_dir/${location_array[$i]}/falsecolor -l $results_dir/${location_array[$i]}/landmasks -p $results_dir/${location_array[$i]}/soit -o /tmp
         """

--- a/workflow/scripts/pass_time_cylc.py
+++ b/workflow/scripts/pass_time_cylc.py
@@ -50,8 +50,8 @@ def get_passtimes(
     configUsr = SPACEUSER
     configPwd = SPACEPSWD
     siteCred = {"identity": configUsr, "password": configPwd}
-    end_date = datetime.datetime.strptime(enddate, "%Y-%m-%d").strftime("%m-%d-%Y").split("-")
-    start_date = datetime.datetime.strptime(startdate, "%Y-%m-%d").strftime("%m-%d-%Y").split("-")
+    end_date = _parsedate(enddate)
+    start_date = _parsedate(startdate)
     lat = float(centroid_lat)
     lon = float(centroid_lon)
     print(f"Outpath {csvoutpath}")

--- a/workflow/scripts/pass_time_cylc.py
+++ b/workflow/scripts/pass_time_cylc.py
@@ -44,9 +44,7 @@ def _parsedate(date):
     return datetime.datetime.strptime(date, "%Y-%m-%d").strftime("%m-%d-%Y").split("-")
 
 
-def get_passtimes(
-    start_date, end_date, csvoutpath, lat, lon, SPACEUSER, SPACEPSWD
-):
+def get_passtimes(start_date, end_date, csvoutpath, lat, lon, SPACEUSER, SPACEPSWD):
     siteCred = {"identity": SPACEUSER, "password": SPACEPSWD}
     print(f"Outpath {csvoutpath}")
     print(f"Timeframe starts on {start_date}, and ends on {end_date}")
@@ -234,20 +232,6 @@ def get_Data(credentials: dict, start_date, end_date):
         # No more requests.
         session.close()
     return aquaData, terraData
-
-
-def getlatlon(config):
-    # Read in area of interest latitude and longitude values from configuration file.
-    try:
-        lat = float(config.get("configuration", "latitude of interest"))
-        long = float(config.get("configuration", "longitude of interest"))
-    except ValueError:
-        print(
-            "Looks like there may be an issue with your lat/long values.",
-            "Check the configuration file and try again.",
-        )
-        quit()
-    return lat, long
 
 
 def getclosest(aqua, terra, aoi, t0, t1, altitude_degrees=30):

--- a/workflow/scripts/pass_time_cylc.py
+++ b/workflow/scripts/pass_time_cylc.py
@@ -354,12 +354,14 @@ def main():
     )
     parser.add_argument(
         "--startdate",
-        type=str,
+        type=_parsedate,
+        dest="start_date",
         help="Start date in format YYYY-MM-DD",
     )
     parser.add_argument(
         "--enddate",
-        type=str,
+        type=_parsedate,
+        dest="end_date",
         help="End date in format YYYY-MM-DD",
     )
     parser.add_argument(

--- a/workflow/scripts/pass_time_cylc.py
+++ b/workflow/scripts/pass_time_cylc.py
@@ -365,17 +365,19 @@ def main():
         help="End date in format YYYY-MM-DD",
     )
     parser.add_argument(
-        "--centroid_lat",
-        "-lat",
-        metavar="centroid_lat",
-        type=str,
+        "--centroid-lat",
+        "--lat",
+        metavar="lat",
+        dest="lat",
+        type=float,
         help="latitude of bounding box centroid",
     )
     parser.add_argument(
-        "--centroid_lon",
-        "-lon",
-        metavar="centroid_lon",
-        type=str,
+        "--centroid-lon",
+        "--lon",
+        metavar="lon",
+        dest="lon",
+        type=float,
         help="longitude of bounding box centroid",
     )
     parser.add_argument(

--- a/workflow/scripts/pass_time_cylc.py
+++ b/workflow/scripts/pass_time_cylc.py
@@ -45,18 +45,12 @@ def _parsedate(date):
 
 
 def get_passtimes(
-    startdate, enddate, csvoutpath, centroid_lat, centroid_lon, SPACEUSER, SPACEPSWD
+    start_date, end_date, csvoutpath, lat, lon, SPACEUSER, SPACEPSWD
 ):
-    configUsr = SPACEUSER
-    configPwd = SPACEPSWD
-    siteCred = {"identity": configUsr, "password": configPwd}
-    end_date = _parsedate(enddate)
-    start_date = _parsedate(startdate)
-    lat = float(centroid_lat)
-    lon = float(centroid_lon)
+    siteCred = {"identity": SPACEUSER, "password": SPACEPSWD}
     print(f"Outpath {csvoutpath}")
     print(f"Timeframe starts on {start_date}, and ends on {end_date}")
-    print(f"Coordinates (x, y): ({centroid_lat}, {centroid_lon})")
+    print(f"Coordinates (x, y): ({lat}, {lon})")
 
     end_date = getNextDay(end_date)
 

--- a/workflow/scripts/pass_time_cylc.py
+++ b/workflow/scripts/pass_time_cylc.py
@@ -40,6 +40,10 @@ class MyError(Exception):
         self.args = args
 
 
+def _parsedate(date):
+    return datetime.datetime.strptime(date, "%Y-%m-%d").strftime("%m-%d-%Y").split("-")
+
+
 def get_passtimes(
     startdate, enddate, csvoutpath, centroid_lat, centroid_lon, SPACEUSER, SPACEPSWD
 ):

--- a/workflow/scripts/pass_time_cylc.py
+++ b/workflow/scripts/pass_time_cylc.py
@@ -106,8 +106,7 @@ def get_passtimes(
 def csvwrite(startdate, enddate, lat, lon, rows, outpath):
     fields = ["Date", "Aqua pass time", "Terra pass time"]
     filename = f"{outpath}/passtimes_lat{lat}_lon{lon}_{''.join(startdate)}_{''.join(enddate)}.csv"
-
-    with open(filename, "w") as csvfile:
+    with open(filename, "w", newline='') as csvfile:
         csvwriter = csv.writer(csvfile)
         csvwriter.writerow(fields)
         csvwriter.writerows(rows)

--- a/workflow/scripts/pass_time_cylc.py
+++ b/workflow/scripts/pass_time_cylc.py
@@ -77,266 +77,27 @@ def get_passtimes(
     rows = []
 
     # Loop through each day until the end date of interest is reached.
-    while True:
+    while not np.array_equiv(tomorrow, end_date):
         # Get UTC time values of the start of today and the start of tomorrow.
         # Passes between these times are considered.
-        t0 = ts.utc(int(today[2]), int(today[0]), int(today[1]))
-        t1 = ts.utc(int(tomorrow[2]), int(tomorrow[0]), int(tomorrow[1]))
+        t0 = to_utc(today)
+        t1 = to_utc(tomorrow)
 
-        # Load in aqua TLE from space track data.
-        aqua_tleline1 = aquaData[aqua_i]["TLE_LINE1"]
-        aqua_tleline2 = aquaData[aqua_i]["TLE_LINE2"]
-
-        # Create new aqua satellite with this TLE.
+        min_diff_index, closest_aqua_epoch_to_t0 = getclosestepoch(t0, aquaData)
+        aqua_tleline1, aqua_tleline2 = get_tli_lines(aquaData[min_diff_index])
         aqua = EarthSatellite(aqua_tleline1, aqua_tleline2, "AQUA", ts)
 
-        # Load in terra TLE from space track data.
-        terra_tleline1 = terraData[terra_i]["TLE_LINE1"]
-        terra_tleline2 = terraData[terra_i]["TLE_LINE2"]
-
-        # Create new terra satellite with this TLE.
+        min_diff_index, closest_terra_epoch_to_t0 = getclosestepoch(t0, terraData)
+        terra_tleline1, terra_tleline2 = get_tli_lines(terraData[min_diff_index])
         terra = EarthSatellite(terra_tleline1, terra_tleline2, "TERRA", ts)
 
-        # Update aqua index. If the epoch of the current TLE is more than a day away from the area of interest,
-        # go to a newer TLE. This keeps the TLE epoch close to the date of the pass, decreasing error in the orbital
-        # mechanics algorithm.
-        while (t0 - aqua.epoch) > 1:
-            aqua_i += 1
-            aqua_tleline1 = aquaData[aqua_i]["TLE_LINE1"]
-            aqua_tleline2 = aquaData[aqua_i]["TLE_LINE2"]
-            aqua = EarthSatellite(aqua_tleline1, aqua_tleline2, "AQUA", ts)
-
-        # Update terra index.
-        while (t0 - terra.epoch) > 1:
-            terra_i += 1
-            terra_tleline1 = terraData[terra_i]["TLE_LINE1"]
-            terra_tleline2 = terraData[terra_i]["TLE_LINE2"]
-            terra = EarthSatellite(terra_tleline1, terra_tleline2, "TERRA", ts)
-
-        # Find times in the time interval of interest where aqua's position in the sky passes over 30º for an observer
-        # in the area of interest, i.e. when it's passing by relatively close.
-        aqua_t, aqua_events = aqua.find_events(
-            aoi, t0, t1, altitude_degrees=30.0)
-
-        # Create empty arrays of today's passes and a dict for each pass.
-        todays_aqua_passes = []
-        aqua_passdict = {}
-
-        # Loop through all Aqua events.
-        for i in range(len(aqua_events)):
-            # Get first event type and time.
-            event = aqua_events[i]
-            ti = aqua_t[i]
-
-            # If this is the first event in the list and it's of type "overpass", this means that the rise of this
-            # pass occurred on the previous day. This is an edge case when the area of interest is near the
-            # international date line. The rise location values are set to nan, since these aren't necessary or easy to
-            # retrieve in this case. The location of the satellite at the overpass point, the overpass time, and the
-            # distance to the aoi at this point are recorded in the dictionary.
-            if event == 1 and i == 0:
-                aqua_passdict["rise_lat"] = float("nan")
-                aqua_passdict["rise_lon"] = float("nan")
-                difference = aqua - aoi
-                topocentric = difference.at(ti)
-                alt, az, distance = topocentric.altaz()
-                aqua_passdict["distance"] = distance.km
-                aqua_passdict["time"] = ti.utc_strftime("%Y %b %d %H:%M:%S")
-
-                geocentric = aqua.at(ti)
-                overlat, overlon = wgs84.latlon_of(geocentric)
-                aqua_passdict["over_lat"] = overlat.degrees
-                aqua_passdict["over_lon"] = overlon.degrees
-
-            # This is another edge case when the first event in the list is of type "set". This occurs when the
-            # satellite rises and passes over on the previous day, then sets today. If the overpass occurred yesterday,
-            # it is already counted yesterday, so this event is ignored.
-            elif event == 2 and i == 0:
-                pass
-
-            # This is an edge case where the final event of the day is an overpass. If so, this means that the satellite
-            # sets on the next day, so the set location is set to nan.
-            elif i == len(aqua_events) and event == 1:
-                difference = aqua - aoi
-
-                topocentric = difference.at(ti)
-
-                alt, az, distance = topocentric.altaz()
-                aqua_passdict["distance"] = distance.km
-                aqua_passdict["time"] = ti.utc_strftime("%Y %b %d %H:%M:%S")
-
-                geocentric = aqua.at(ti)
-                overlat, overlon = wgs84.latlon_of(geocentric)
-                aqua_passdict["over_lat"] = overlat.degrees
-                aqua_passdict["over_lon"] = overlon.degrees
-
-                aqua_passdict["set_lat"] = float("nan")
-                aqua_passdict["set_lon"] = float("nan")
-                todays_aqua_passes.append(aqua_passdict)
-
-            # If the event is a 'rise', save the rise longitude and latitude to the dict representing the pass.
-            elif event == 0:
-                aqua_passdict = {}
-                geocentric = aqua.at(ti)
-                riselat, riselon = wgs84.latlon_of(geocentric)
-                aqua_passdict["rise_lat"] = riselat.degrees
-                aqua_passdict["rise_lon"] = riselon.degrees
-
-            # If the event is an 'overpass', save the overpass longitude and latitude, the time, and the minimum
-            # distance to the aoi to the dict representing the pass.
-            elif event == 1:
-                difference = aqua - aoi
-
-                topocentric = difference.at(ti)
-
-                alt, az, distance = topocentric.altaz()
-                aqua_passdict["distance"] = distance.km
-                aqua_passdict["time"] = ti.utc_strftime("%Y %b %d %H:%M:%S")
-
-                geocentric = aqua.at(ti)
-                overlat, overlon = wgs84.latlon_of(geocentric)
-                aqua_passdict["over_lat"] = overlat.degrees
-                aqua_passdict["over_lon"] = overlon.degrees
-
-            # If the event is a 'set', save the set longitude and latitude to the dict representing the pass.
-            else:
-                geocentric = terra.at(ti)
-                setlat, setlon = wgs84.latlon_of(geocentric)
-                aqua_passdict["set_lat"] = setlat.degrees
-                aqua_passdict["set_lon"] = setlon.degrees
-                todays_aqua_passes.append(aqua_passdict)
-
-        # Assume the minimum distance for a pass is very large until proven otherwise.
-        least_distance = math.inf
-
-        # Time of closest pass.
-        closest_time = ""
-
-        # Loop through each pass in the list of passes.
-        for pass_dict in todays_aqua_passes:
-            # If the rising latitude of the pass is less than the overpass latitude of the pass, this is a ascending
-            # pass, which means a daytime pass for Aqua. These are the only passes of interest. If, furthermore, it's
-            # less than the current minimum distance between the overpass and the aoi, this is the new closest pass.
-            if not np.isnan(pass_dict["rise_lat"]):
-                if (pass_dict["rise_lat"] < pass_dict["over_lat"]) and (
-                    pass_dict["distance"] < least_distance
-                ):
-                    least_distance = pass_dict["distance"]
-                    closest_time = pass_dict["time"]
-
-            # For some edge case passes, rise latitude values are undefined. In this case, compare overpass latitude and
-            # set latitude values. If the overpass latitude is less than the set latitude, it's an ascending pass.
-            else:
-                if (pass_dict["set_lat"] > pass_dict["over_lat"]) and (
-                    pass_dict["distance"] < least_distance
-                ):
-                    least_distance = pass_dict["distance"]
-                    closest_time = pass_dict["time"]
-
-        # Save this closest time as determined above.
-        aqua_closest = closest_time.split(" ")[3]
-
-        # Repeat for Terra.
-        terra_t, terra_events = terra.find_events(
-            aoi, t0, t1, altitude_degrees=30.0)
-
-        todays_terra_passes = []
-        terra_passdict = {}
-
-        # Do the same as above for all terra events.
-        for i in range(len(terra_events)):
-            event = terra_events[i]
-            ti = terra_t[i]
-
-            if event == 1 and i == 0:
-                terra_passdict["rise_lat"] = float("nan")
-                terra_passdict["rise_lon"] = float("nan")
-                difference = terra - aoi
-                topocentric = difference.at(ti)
-                alt, az, distance = topocentric.altaz()
-                terra_passdict["distance"] = distance.km
-                terra_passdict["time"] = ti.utc_strftime("%Y %b %d %H:%M:%S")
-
-                geocentric = terra.at(ti)
-                overlat, overlon = wgs84.latlon_of(geocentric)
-                terra_passdict["over_lat"] = overlat.degrees
-                terra_passdict["over_lon"] = overlon.degrees
-            elif event == 2 and i == 0:
-                pass
-            elif i == len(terra_events) and event == 1:
-                difference = terra - aoi
-
-                topocentric = difference.at(ti)
-
-                alt, az, distance = topocentric.altaz()
-                terra_passdict["distance"] = distance.km
-                terra_passdict["time"] = ti.utc_strftime("%Y %b %d %H:%M:%S")
-
-                geocentric = terra.at(ti)
-                overlat, overlon = wgs84.latlon_of(geocentric)
-                terra_passdict["over_lat"] = overlat.degrees
-                terra_passdict["over_lon"] = overlon.degrees
-
-                terra_passdict["set_lat"] = float("nan")
-                terra_passdict["set_lon"] = float("nan")
-                todays_terra_passes.append(terra_passdict)
-
-            elif event == 0:
-                terra_passdict = {}
-                geocentric = terra.at(ti)
-                riselat, riselon = wgs84.latlon_of(geocentric)
-                terra_passdict["rise_lat"] = riselat.degrees
-                terra_passdict["rise_lon"] = riselon.degrees
-            elif event == 1:
-                difference = terra - aoi
-
-                topocentric = difference.at(ti)
-
-                alt, az, distance = topocentric.altaz()
-                terra_passdict["distance"] = distance.km
-                terra_passdict["time"] = ti.utc_strftime("%Y %b %d %H:%M:%S")
-
-                geocentric = terra.at(ti)
-                overlat, overlon = wgs84.latlon_of(geocentric)
-                terra_passdict["over_lat"] = overlat.degrees
-                terra_passdict["over_lon"] = overlon.degrees
-            else:
-                geocentric = terra.at(ti)
-                setlat, setlon = wgs84.latlon_of(geocentric)
-                terra_passdict["set_lat"] = setlat.degrees
-                terra_passdict["set_lon"] = setlon.degrees
-                todays_terra_passes.append(terra_passdict)
-
-        least_distance = math.inf
-
-        closest_time = ""
-
-        for pass_dict in todays_terra_passes:
-            # If the rising latitude of the pass is greater than the overpass latitude of the pass, this is a descending
-            # pass, which means a daytime pass for Terra. These are the only passes of interest. If, furthermore, it's
-            # less than the current minimum distance between the overpass and the aoi, this is the new closest pass.
-            if not np.isnan(pass_dict["rise_lat"]):
-                if (pass_dict["rise_lat"] > pass_dict["over_lat"]) and (pass_dict["distance"] < least_distance):
-                    least_distance = pass_dict["distance"]
-                    closest_time = pass_dict["time"]
-
-            # For some edge case passes, rise latitude values are undefined. In this case, compare overpass latitude and
-            # set latitude values. If the overpass latitude is greater than the set latitude, it's a descending pass.
-            else:
-                if (pass_dict["set_lat"] < pass_dict["over_lat"]) and (pass_dict["distance"] < least_distance):
-                    least_distance = pass_dict["distance"]
-                    closest_time = pass_dict["time"]
-
-        terra_closest = closest_time.split(" ")[3]
+        aqua_closest, terra_closest = getclosest(aqua, terra, aoi, t0, t1)
 
         # Add closest passes of the day to array of passes.
         rows.append(["-".join(today), aqua_closest, terra_closest])
 
-        # If today is the end date, break, otherwise set the current day to tomorrow.
-        if np.array_equiv(tomorrow, end_date):
-            break
-        else:
-            today = getNextDay(today)
-            tomorrow = getNextDay(today)
+        today = getNextDay(today)
+        tomorrow = getNextDay(today)
 
     csvwrite(start_date, end_date, lat, lon, rows, csvoutpath)
 

--- a/workflow/scripts/pass_time_cylc.py
+++ b/workflow/scripts/pass_time_cylc.py
@@ -60,7 +60,6 @@ def get_passtimes(
 
     end_date = getNextDay(end_date)
 
-
     aquaData, terraData = get_Data(siteCred, start_date, end_date)
 
     # Load in orbital mechanics tool timescale.
@@ -106,7 +105,7 @@ def get_passtimes(
 def csvwrite(startdate, enddate, lat, lon, rows, outpath):
     fields = ["Date", "Aqua pass time", "Terra pass time"]
     filename = f"{outpath}/passtimes_lat{lat}_lon{lon}_{''.join(startdate)}_{''.join(enddate)}.csv"
-    with open(filename, "w", newline='') as csvfile:
+    with open(filename, "w", newline="") as csvfile:
         csvwriter = csv.writer(csvfile)
         csvwriter.writerow(fields)
         csvwriter.writerows(rows)
@@ -344,7 +343,9 @@ def getclosest(aqua, terra, aoi, t0, t1, altitude_degrees=30):
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Aqua and Terra Satellite Overpass time tool")
+    parser = argparse.ArgumentParser(
+        description="Aqua and Terra Satellite Overpass time tool"
+    )
     parser.add_argument(
         "--SPACEUSER",
         "-u",
@@ -393,5 +394,4 @@ def main():
 
 
 if __name__ == "__main__":
-
     main()


### PR DESCRIPTION
The pull request includes several commits that refactor the overpass time calculation logic in for the SOIT script. These changes aim to make the code more modular, abstract, and optimized.

Additionally, and crucially, it fixes the bug in #145 by leveraging the epoch data retrieved from SpaceTrack without using calls to EarthSatellite.

The old version of the script failed with the following input metadata (see #145):
```
start date = 03/31/2013
end date = 05/01/2013

latitude of interest = 76.0015
longitude of interest = -18.4315
```

The new version of the script can be tested using the following call from the command line:
```sh
python pass_time_cylc.py -u myuser@foo.com -p 'mypassword' --startdate 2013-03-31 --enddate 2013-05-01 --lat 76.0015 --lon -18.4315 --csvoutpath .
```
