### PR TITLE
change icelabels to clear pixels within dilated land mask

### DIFF
--- a/src/preprocess.jl
+++ b/src/preprocess.jl
@@ -147,7 +147,7 @@ function preprocess(
     # 2. Intermediate images
     @info "Finding ice labels"
     ice_labels = IceFloeTracker.find_ice_labels(
-        falsecolor_image, landmask_imgs.non_dilated
+        falsecolor_image, landmask_imgs.dilated
     )
 
     @info "Sharpening truecolor image"


### PR DESCRIPTION
A direct cause of the landmask bleed appears to be that the k-means cluster chosen in segmentation F as ice is based on the mode of the ice labels. Since the clustering in segmentation F is on an image with the dilated landmask superimposed, and the ice labels were created with a non dilated mask, it can happen that patches of pixels labeled as ice fall within the landmask. In those situations, the landmask cluster can be selected as the one with the most pixels. So enforcing consistency between the ice label creation and the k-means cluster selection will at least help. I tested this simple fix for test cases 283-hudson_bay and for 024-baffin_bay.

Hudson Bay before the 1-line change:
![image](https://github.com/user-attachments/assets/e33ea1a5-2ff1-486f-a822-1929600fe82c)


Hudson Bay after the 1-line change:
![image](https://github.com/user-attachments/assets/05fa8e05-4686-4a42-becc-da98f2ce0dc9)

Baffin Bay before the 1-line change:
![image](https://github.com/user-attachments/assets/639506f8-8ce2-419e-8baf-14d3f6d8f140)

Baffin Bay after the 1-line change:
![image](https://github.com/user-attachments/assets/7bb252de-7f32-4afb-bd65-428fac4048c9)
