### PR TITLE
feat: update choose_dtype function to include new types

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,13 +38,9 @@ jobs:
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
-        with:
-          project: IFTPipeline.jl
         env:
           PYTHON: python
       - uses: julia-actions/julia-runtest@v1
-        with:
-          project: IFTPipeline.jl  
         env:
           PYTHON: python
       - uses: julia-actions/julia-processcoverage@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,9 +38,13 @@ jobs:
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
+        with:
+          project: IFTPipeline.jl
         env:
           PYTHON: python
       - uses: julia-actions/julia-runtest@v1
+        with:
+          project: IFTPipeline.jl  
         env:
           PYTHON: python
       - uses: julia-actions/julia-processcoverage@v1

--- a/src/h5.jl
+++ b/src/h5.jl
@@ -19,18 +19,21 @@ Choose the appropriate unsigned integer type based on a maximum value.
 
 # Returns
     
-      * `UInt8` if `mx` is less than or equal to 255.
-      * `UInt16` if `mx` is less than or equal to 65535.
-      * `UInt32` if `mx` is less than or equal to 4294967295.
+      * `UInt8` if 0 ≤ `mx` ≤ 255.
+      * `UInt16` if 0 ≤ `mx` ≤ 65535.
+      * `UInt32` if 0 ≤ `mx` ≤ 2^32 - 1.
+      * `UInt64` if 0 ≤ `mx` ≤ 2^64 - 1.
+      * `UInt128` if 0 ≤ `mx` ≤ 2^128 - 1.
+
 """
-function choose_dtype(mx)
-    types = [UInt8, UInt16, UInt32]
-    for (i, t) in enumerate(types)
-        b = 2^(2^(2 + i)) - 1
-        if mx <= b
-            return t
+function choose_dtype(mx::T) where {T <: Integer}
+    types = [UInt8, UInt16, UInt32, UInt64, UInt128]
+    for t_ in types
+        if typemin(t_) <= mx <= typemax(t_)
+            return t_
         end
     end
+    throw("$mx can't be represented by any of $types")
 end
 
 

--- a/test/test-h5.jl
+++ b/test/test-h5.jl
@@ -78,6 +78,10 @@ h5path = joinpath(resdir, "hdf5-files", "20220914T1244.aqua.labeled_image.250m.h
     @test choose_dtype(100) == UInt8
     @test choose_dtype(300) == UInt16
     @test choose_dtype(70_000) == UInt32
+    @test choose_dtype(18_446_744_073_709_551_615) == UInt64
+    @test choose_dtype(18_446_744_073_709_551_616) == UInt128
+    @test choose_dtype(340_282_366_920_938_463_463_374_607_431_768_211_455) == UInt128
+    @test_throws "can't be represented" choose_dtype(340_282_366_920_938_463_463_374_607_431_768_211_456) 
 end
 
 # clean up

--- a/test/test-h5.jl
+++ b/test/test-h5.jl
@@ -75,6 +75,7 @@ h5path = joinpath(resdir, "hdf5-files", "20220914T1244.aqua.labeled_image.250m.h
     @test typeof(props) == Matrix{Float64}
     close(fid)
 
+    @test_throws "can't be represented" choose_dtype(-1) 
     @test choose_dtype(100) == UInt8
     @test choose_dtype(300) == UInt16
     @test choose_dtype(70_000) == UInt32

--- a/test/test-h5.jl
+++ b/test/test-h5.jl
@@ -81,8 +81,8 @@ h5path = joinpath(resdir, "hdf5-files", "20220914T1244.aqua.labeled_image.250m.h
     @test choose_dtype(70_000) == UInt32
     @test choose_dtype(18_446_744_073_709_551_615) == UInt64
     @test choose_dtype(18_446_744_073_709_551_616) == UInt128
-    @test choose_dtype(340_282_366_920_938_463_463_374_607_431_768_211_455) == UInt128
-    @test_throws "can't be represented" choose_dtype(340_282_366_920_938_463_463_374_607_431_768_211_456) 
+    @test choose_dtype(BigInt(2)^128 - 1) == UInt128
+    @test_throws "can't be represented" choose_dtype(BigInt(2)^128) 
 end
 
 # clean up

--- a/test/test-h5.jl
+++ b/test/test-h5.jl
@@ -79,8 +79,8 @@ h5path = joinpath(resdir, "hdf5-files", "20220914T1244.aqua.labeled_image.250m.h
     @test choose_dtype(100) == UInt8
     @test choose_dtype(300) == UInt16
     @test choose_dtype(70_000) == UInt32
-    @test choose_dtype(18_446_744_073_709_551_615) == UInt64
-    @test choose_dtype(18_446_744_073_709_551_616) == UInt128
+    @test choose_dtype(BigInt(2)^64 - 1) == UInt64
+    @test choose_dtype(BigInt(2)^64) == UInt128
     @test choose_dtype(BigInt(2)^128 - 1) == UInt128
     @test_throws "can't be represented" choose_dtype(BigInt(2)^128) 
 end


### PR DESCRIPTION
Add UInt64 and UInt128, which may be required for the updated pipeline.

Drive-by improvements: 
- make it more obvious that the function is doing what it's meant to do.
- add new testcases
- throw an error if the number can't be represented by any of the types

Part of:
- #149 
