### PR TITLE
add IFT from source repo rather than general registry

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,8 +18,10 @@ TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 ArgParse = "1.1"
 Folds = "0.2"
 HDF5 = "0.16, 0.17"
-IceFloeTracker = "0"
 LoggingExtras = "1.0"
 Pkg = "1.9"
 PyCall = "1.96"
 TOML = "1.0"
+
+[source]
+IceFloeTracker = {url = "https://github.com/WilhelmusLab/IceFloeTracker.jl", rev = "main"}


### PR DESCRIPTION
I added IceFloeTracker from source rather than from the General Registry so that we can update the existing Docker containers for the lab. The build fixes in recent PRs in IceFloeTracker.jl (version 0.6.0) are expected to fix the builds in the containers as well. 

Automerging to the Julia General Registry is held up by Python 3.12, but @cpaniaguam tested successfully with lesser Python versions.

In this PR, I ran the tests for IFTPipeline successfully after adding IceFloeTracker in the [source] block. Merging this PR should trigger the actions to rebuild the Fetchdata and Julia containers and push to Docker Hub.