### PR TITLE
feature: add `track_single` CLI command to track floes in individual files

### DIFF
--- a/IFTPipeline.jl/Project.toml
+++ b/IFTPipeline.jl/Project.toml
@@ -29,5 +29,5 @@ PyCall = "1.96"
 TOML = "1.0"
 
 [source.IceFloeTracker]
-rev = "main"
+rev = "support-labeled-segmented-images"
 url = "https://github.com/WilhelmusLab/IceFloeTracker.jl"

--- a/IFTPipeline.jl/Project.toml
+++ b/IFTPipeline.jl/Project.toml
@@ -29,5 +29,5 @@ PyCall = "1.96"
 TOML = "1.0"
 
 [source.IceFloeTracker]
-rev = "support-labeled-segmented-images"
+rev = "main"
 url = "https://github.com/WilhelmusLab/IceFloeTracker.jl"

--- a/IFTPipeline.jl/Project.toml
+++ b/IFTPipeline.jl/Project.toml
@@ -5,11 +5,13 @@ version = "0.1.0"
 
 [deps]
 ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"
+CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 CSVFiles = "5d742f6a-9f54-50ce-8119-2520741973ca"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 Folds = "41a02a25-b8f0-4f67-bc48-60067656b558"
 HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
 IceFloeTracker = "04643c7a-9ac6-48c5-822f-2704f9e70bd3"
+Images = "916415d5-f1e6-5110-898d-aaa5f9f070e0"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 LoggingExtras = "e6f89c97-d47a-5376-807f-9c37f3926c36"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/IFTPipeline.jl/src/IFTPipeline.jl
+++ b/IFTPipeline.jl/src/IFTPipeline.jl
@@ -14,6 +14,8 @@ using HDF5
 using TOML: parsefile
 using Pkg
 using FileIO
+using Images
+using CSV
 
 include("cli.jl")
 include("soit-parser.jl")

--- a/IFTPipeline.jl/src/cli.jl
+++ b/IFTPipeline.jl/src/cli.jl
@@ -249,6 +249,141 @@ function mkclitrack!(settings)
     return nothing
 end
 
+function mkclitrack_single!(settings)
+    add_arg_group!(settings["track_single"], "arguments")
+    @add_arg_table! settings["track_single"] begin
+        "--imgs"
+        help = "Paths to segmented images"
+        required = true
+        nargs = '+'
+        arg_type = String
+
+        "--props"
+        help = "Paths to extracted features"
+        required = true
+        nargs = '+'
+        arg_type = String
+
+        "--passtimes"
+        help = "Path to object with satellite pass times"
+        required = true
+        nargs = '+'
+        arg_type = DateTime
+
+        "--latlon"
+        help = "Path to geotiff image with latitude/longitude data"
+        required = true
+
+        "--output", "-o"
+        help = "Output file"
+        required = true
+    end
+
+    add_arg_group!(settings["track_single"], "optional arguments")
+    @add_arg_table! settings["track_single"] begin
+
+        "--area"
+        help = "Area thresholds to use for pairing floes"
+        arg_type = Int64
+        default = 1200
+
+        "--dist"
+        help = "Distance threholds to use for pairing floes"
+        default = [15, 30, 120]
+        arg_type = Int
+        nargs = '+'
+
+        "--dt-thresh"
+        help = "Time thresholds to use for pairing floes"
+        default = [30, 100, 1300]
+        arg_type = Int
+        nargs = '+'
+
+        "--Sarearatio"
+        help = "Area ratio threshold for small floes"
+        arg_type = Float64
+        default = 0.18
+
+        "--Smajaxisratio"
+        help = "Major axis ratio threshold for small floes"
+        arg_type = Float64
+        default = 0.1
+
+        "--Sminaxisratio"
+        help = "Minor axis ratio threshold for small floes"
+        arg_type = Float64
+        default = 0.12
+
+        "--Sconvexarearatio"
+        help = "Convex area ratio threshold for small floes"
+        arg_type = Float64
+        default = 0.14
+
+        "--Larearatio"
+        help = "Area ratio threshold for large floes"
+        arg_type = Float64
+        default = 0.28
+
+        "--Lmajaxisratio"
+        help = "Major axis ratio threshold for large floes"
+        arg_type = Float64
+        default = 0.1
+
+        "--Lminaxisratio"
+        help = "Minor axis ratio threshold for large floes"
+        arg_type = Float64
+        default = 0.15
+
+        "--Lconvexarearatio"
+        help = "Convex area ratio threshold for large floes"
+        arg_type = Float64
+        default = 0.14
+
+        # matchcorr computation
+        "--mxrot"
+        help = "Maximum rotation"
+        arg_type = Int64
+        default = 10
+
+        "--psi"
+        help = "Minimum psi-s correlation"
+        arg_type = Float64
+        default = 0.95
+
+        "--sz"
+        help = "Minimum side length of floe mask"
+        arg_type = Int64
+        default = 16
+
+        "--comp"
+        help = "Size comparability"
+        arg_type = Float64
+        default = 0.25
+
+        "--mm"
+        help = "Maximum registration mismatch"
+        arg_type = Float64
+        default = 0.22
+
+        # Goodness of match
+        "--corr"
+        help = "Mininimun psi-s correlation"
+        arg_type = Float64
+        default = 0.68
+
+        "--area2"
+        help = "Large floe area mismatch threshold"
+        arg_type = Float64
+        default = 0.236
+
+        "--area3"
+        help = "Small floe area mismatch threshold"
+        arg_type = Float64
+        default = 0.18
+    end
+    return nothing
+end
+
 function mkclilandmask!(settings)
     args = [
         "input",
@@ -285,7 +420,8 @@ function mkcli!(settings, common_args)
         "extractfeatures" => mkcliextract!,
         "extractfeatures_single" => mkcliextract_single!,
         "makeh5files" => mkclimakeh5!,
-        "track" => mkclitrack!
+        "track" => mkclitrack!,
+        "track_single" => mkclitrack_single!,
     )
 
     for t in keys(d)
@@ -330,6 +466,10 @@ function main()
         action = :command
 
         "track"
+        help = "Pair ice floes in day k with ice floes in day k+1"
+        action = :command
+
+        "track_single"
         help = "Pair ice floes in day k with ice floes in day k+1"
         action = :command
     end

--- a/test/test-IFTPipeline.jl-cli.sh
+++ b/test/test-IFTPipeline.jl-cli.sh
@@ -29,16 +29,21 @@ export JULIA_DEBUG="Main,IFTPipeline,IceFloeTracker"
 # Run the processing (single files)
 LANDMASK=${DATA_TARGET}/landmask.tiff
 LANDMASK_NON_DILATED=${DATA_TARGET}/landmask.non-dilated.tiff
-LANDMASK_DILATED=${DATA_TARGET}/landmask.dilated.tiff 
-TRUECOLOR=${DATA_TARGET}/20220914.terra.truecolor.250m.tiff
-FALSECOLOR=${DATA_TARGET}/20220914.terra.falsecolor.250m.tiff
-SEGMENTED=${DATA_TARGET}/20220914.terra.segmented.250m.tiff
-FLOEPROPERTIES=${DATA_TARGET}/20220914.terra.segmented.250m.props.csv
-
-# Run the processing (single file)
+LANDMASK_DILATED=${DATA_TARGET}/landmask.dilated.tiff
 ${IFT} landmask_single -i ${LANDMASK} -o ${LANDMASK_NON_DILATED} -d ${LANDMASK_DILATED}
-${IFT} preprocess_single --truecolor ${TRUECOLOR} --falsecolor ${FALSECOLOR} --landmask ${LANDMASK_NON_DILATED} --landmask-dilated ${LANDMASK_DILATED} --output ${SEGMENTED}
-${IFT} extractfeatures_single --input ${SEGMENTED} --output ${FLOEPROPERTIES}
+
+for satellite in "aqua" "terra"
+do
+    TRUECOLOR=${DATA_TARGET}/20220914.${satellite}.truecolor.250m.tiff
+    FALSECOLOR=${DATA_TARGET}/20220914.${satellite}.falsecolor.250m.tiff
+    SEGMENTED=${DATA_TARGET}/20220914.${satellite}.segmented.250m.tiff
+    FLOEPROPERTIES=${DATA_TARGET}/20220914.${satellite}.segmented.250m.props.csv
+    ${IFT} preprocess_single --truecolor ${TRUECOLOR} --falsecolor ${FALSECOLOR} --landmask ${LANDMASK_NON_DILATED} --landmask-dilated ${LANDMASK_DILATED} --output ${SEGMENTED}
+    ${IFT} extractfeatures_single --input ${SEGMENTED} --output ${FLOEPROPERTIES}
+done
+
+${IFT} track_single --imgs "${DATA_TARGET}/20220914.{aqua,terra}.segmented.250m.tiff" --props "${DATA_TARGET}/20220914.{aqua,terra}.segmented.250m.props.csv" --latlon ${TRUECOLOR} --passtimes "2022-09-14T12:00:00" "2022-09-15T12:00:00" --output ${DATA_TARGET}/paired-floes.csv
+
 
 
 # Run the processing (batch)


### PR DESCRIPTION
Add a single-file version of the extractfeatures script.

Call it like this:
```bash
${IFT} track_single \
--latlon ${TRUECOLOR} \
--imgs segmented_image_0.tiff segmented_image_1.tiff \
--props floe_properties_0.csv floe_properties_1.csv \
--passtimes "2022-09-14T12:00:00" "2022-09-15T12:00:00" \
--output paired-floes.csv
```

... where `${IFT}` is the CLI, `${TRUECOLOR}` is the path to a true-color image, and the passtimes are ISO8601 timestamps corresponding to the images and props files.

Adds:
- New CLI command
- New smoke test
- Add CSV dependency
- Add Images dependency
- Update IceFloeTracker.jl to be the version which supports segmented labeled images

Part of:
- #149 

Note: This could just as well be done using a subcommand in EBSEG if we needed it to, removing a larch chunk of the python dependency.