### PR TITLE
feature: add `makeh5files_single` CLI command to track floes in individual files

### DIFF
--- a/IFTPipeline.jl/src/cli.jl
+++ b/IFTPipeline.jl/src/cli.jl
@@ -122,6 +122,45 @@ function mkclimakeh5!(settings)
     return nothing
 end
 
+function mkclimakeh5_single!(settings)
+    @add_arg_table! settings["makeh5files_single"] begin
+        "--iftversion"
+        help = "Version number of the IceFloeTracker.jl package"
+        required = false
+        arg_type = String
+
+        "--passtime"
+        help = "Satellite pass time"
+        required = true
+        arg_type = DateTime
+
+        "--truecolor"
+        help = "Path to truecolor image"
+        required = true
+        arg_type = String
+
+        "--falsecolor"
+        help = "Path to falsecolor image"
+        required = true
+        arg_type = String
+
+        "--labeled"
+        help = "Path to labeled image"
+        required = true
+        arg_type = String
+
+        "--props"
+        help = "Path to extracted features (csv)"
+        required = true
+        arg_type = String
+
+        "--output", "-o"
+        help = "Output file"
+        required = true
+    end
+    return nothing
+end
+
 function mkclitrack!(settings)
     add_arg_group!(settings["track"], "arguments")
     @add_arg_table! settings["track"] begin
@@ -420,6 +459,7 @@ function mkcli!(settings, common_args)
         "extractfeatures" => mkcliextract!,
         "extractfeatures_single" => mkcliextract_single!,
         "makeh5files" => mkclimakeh5!,
+        "makeh5files_single" => mkclimakeh5_single!,
         "track" => mkclitrack!,
         "track_single" => mkclitrack_single!,
     )
@@ -462,6 +502,10 @@ function main()
         action = :command
 
         "makeh5files"
+        help = "Make HDF5 files from extracted floe features"
+        action = :command
+
+        "makeh5files_single"
         help = "Make HDF5 files from extracted floe features"
         action = :command
 

--- a/IFTPipeline.jl/src/h5.jl
+++ b/IFTPipeline.jl/src/h5.jl
@@ -136,3 +136,53 @@ function makeh5files(; pathtosampleimg::String, resdir::String, iftversion=IceFl
     end
     return nothing
 end
+
+
+function makeh5files_single(; passtime::DateTime, iftversion::Union{String, Nothing}=nothing, truecolor::String, falsecolor::String, labeled::String, props::String, output::String)
+    latlondata = getlatlon(truecolor)
+    ptsunix = Int64(Dates.datetime2unix(passtime))
+    labeled_ = Integer.(rawview(channelview((FileIO.load(labeled)))))
+
+    if isnothing(iftversion)
+        iftversion = string(IceFloeTracker.IFTVERSION)
+    end
+
+    props_ = DataFrame(CSV.File(props))
+    colstodrop = [:row_centroid, :col_centroid, :min_row, :min_col, :max_row, :max_col]
+    converttounits!(props_, latlondata, colstodrop)
+    @info props_
+
+    h5open(output, "w") do file
+        # Add top-level attributes
+        attrs(file)["fname_falsecolor"] = falsecolor
+        attrs(file)["fname_truecolor"] = truecolor
+        attrs(file)["iftversion"] = iftversion
+        attrs(file)["crs"] = latlondata["crs"]
+        attrs(file)["reference"] = "https://doi.org/10.1016/j.rse.2019.111406"
+        attrs(file)["contact"] = "mmwilhelmus@brown.edu"
+
+        g = create_group(file, "index")
+        g["time"] = ptsunix
+        g["x"] = latlondata["X"]
+        g["y"] = latlondata["Y"]
+
+        g = create_group(file, "floe_properties")
+        write_dataset(g, "properties", [copy(row) for row in eachrow(props_)])  # `copy(row)` converts the DataSetRow to a NamedTuple
+        attrs(g)["Description of properties"] = """ Area units (`area`, `convex_area`) are in sq. kilometers, length units (`minor_axis_length`, `major_axis_length`, and `perimeter`) in kilometers, and `orientation` in radians (see the description of properties attribute.) Latitude and longitude coordinates are in degrees, and the stereographic coordinates`x` and `y` are in meters relative to the NSIDC north polar stereographic projection. Generated using the `regionprops` function from the `skimage` package. See https://scikit-image.org/docs/0.20.x/api/skimage.measure.html#regionprops
+        """
+
+        mx = maximum(labeled_)
+        T = choose_dtype(mx)
+        # write_dataset(g, "labeled_image", T.(labeled_))
+        imgdata = T.(permutedims(labeled_))
+        obj, dtype = create_dataset(g, "labeled_image", imgdata)
+        attrs(obj)["CLASS"] = "IMAGE"
+        attrs(obj)["IMAGE_SUBCLASS"] = "IMAGE_INDEXED"
+        attrs(obj)["IMAGE_MINMAXRANGE"] = [minimum(imgdata), maximum(imgdata)]
+
+        attrs(obj)["description"] = "Connected components of the segmented floe image using a 3x3 structuring element. The property matrix consists of the properties of each connected component."
+        write_dataset(obj, dtype, imgdata)
+
+    end
+    return nothing
+end

--- a/test/test-IFTPipeline.jl-cli.sh
+++ b/test/test-IFTPipeline.jl-cli.sh
@@ -43,7 +43,7 @@ do
     ${IFT} extractfeatures_single --input ${SEGMENTED} --output ${FLOEPROPERTIES}
 done
 
-${IFT} track_single --imgs "${DATA_TARGET}/20220914.{aqua,terra}.segmented.250m.tiff" --props "${DATA_TARGET}/20220914.{aqua,terra}.segmented.250m.props.csv" --latlon ${TRUECOLOR} --passtimes "2022-09-14T12:00:00" "2022-09-15T12:00:00" --output ${DATA_TARGET}/paired-floes.csv
+${IFT} track_single --imgs ${DATA_TARGET}/20220914.{aqua,terra}.segmented.250m.tiff --props ${DATA_TARGET}/20220914.{aqua,terra}.segmented.250m.props.csv --latlon ${TRUECOLOR} --passtimes "2022-09-14T12:00:00" "2022-09-15T12:00:00" --output ${DATA_TARGET}/paired-floes.csv
 
 
 

--- a/test/test-IFTPipeline.jl-cli.sh
+++ b/test/test-IFTPipeline.jl-cli.sh
@@ -41,6 +41,7 @@ do
     HDF5FILE=${DATA_TARGET}/20220914.${satellite}.h5
     ${IFT} preprocess_single --truecolor ${TRUECOLOR} --falsecolor ${FALSECOLOR} --landmask ${LANDMASK_NON_DILATED} --landmask-dilated ${LANDMASK_DILATED} --output ${SEGMENTED}
     ${IFT} extractfeatures_single --input ${SEGMENTED} --output ${FLOEPROPERTIES}
+    ${IFT} makeh5files_single --passtime "2022-09-14T12:00:00" --truecolor ${TRUECOLOR} --falsecolor ${FALSECOLOR} --labeled ${SEGMENTED} --props ${FLOEPROPERTIES} --output ${HDF5FILE}
 done
 
 ${IFT} track_single --imgs ${DATA_TARGET}/20220914.{aqua,terra}.segmented.250m.tiff --props ${DATA_TARGET}/20220914.{aqua,terra}.segmented.250m.props.csv --latlon ${TRUECOLOR} --passtimes "2022-09-14T12:00:00" "2022-09-15T12:00:00" --output ${DATA_TARGET}/paired-floes.csv

--- a/test/test-IFTPipeline.jl-cli.sh
+++ b/test/test-IFTPipeline.jl-cli.sh
@@ -38,6 +38,7 @@ do
     FALSECOLOR=${DATA_TARGET}/20220914.${satellite}.falsecolor.250m.tiff
     SEGMENTED=${DATA_TARGET}/20220914.${satellite}.segmented.250m.tiff
     FLOEPROPERTIES=${DATA_TARGET}/20220914.${satellite}.segmented.250m.props.csv
+    HDF5FILE=${DATA_TARGET}/20220914.${satellite}.h5
     ${IFT} preprocess_single --truecolor ${TRUECOLOR} --falsecolor ${FALSECOLOR} --landmask ${LANDMASK_NON_DILATED} --landmask-dilated ${LANDMASK_DILATED} --output ${SEGMENTED}
     ${IFT} extractfeatures_single --input ${SEGMENTED} --output ${FLOEPROPERTIES}
 done


### PR DESCRIPTION
Add a single-file version of the HDF5 files script.

Call it like this:
```bash
${IFT} makeh5files_single --truecolor ${TRUECOLOR} --falsecolor ${FALSECOLOR} --labeled ${SEGMENTED} --props ${FLOEPROPERTIES}
```

... where `${IFT}` is the CLI, `${FLOEPROPERTIES}` is the path to the CSV file containing the floe properties, and the other variable names are image files.

Adds:
- New CLI command
- New smoke test

Part of:
- #149 