### PR TITLE
fix(workflow): H5 Export not run

### DIFF
--- a/IFTPipeline.jl/src/cli.jl
+++ b/IFTPipeline.jl/src/cli.jl
@@ -340,7 +340,7 @@ function mkclimakeh5_single!(settings)
         required = true
         arg_type = String
 
-        "--output", "-o"
+        "--output"
         help = "Output file"
         required = true
     end

--- a/workflow/flow.cylc
+++ b/workflow/flow.cylc
@@ -290,7 +290,7 @@
         # Package intermediate and final outputs into HDF5 files
         script = """
         ${IFT} makeh5files_single \
-            --passtime `cat ${overpass_time_file}` \
+            --passtime "$(cat ${overpass_time_file} | tr -d 'Z\n\r')" \
             --truecolor ${truecolor_file} \
             --falsecolor ${falsecolor_file} \
             --labeled ${labeled_file} \

--- a/workflow/flow.cylc
+++ b/workflow/flow.cylc
@@ -17,7 +17,7 @@
         """
         P1D = """
             get_all_overpass_times[^] => get_single_overpass_time<satellite>
-            INIT[^]:succeed-all => LOAD:succeed-all => PREPROCESS:succeed-all => exportH5 => done
+            INIT[^]:succeed-all => LOAD:succeed-all => PREPROCESS:succeed-all => exportH5<satellite> => done
             done[-P1D] => done
 
         """


### PR DESCRIPTION
Ensure that the H5 export is run during the workflow
- Fix its name in the workflow graph
- Ensure the current date-time format is accepted