### PR TITLE
fix: apptainer calls if cylc-run directory is symlinked

### DIFF
--- a/workflow/flow.cylc
+++ b/workflow/flow.cylc
@@ -56,7 +56,7 @@
             {% elif IFT_INSTALL == "Docker" %}
                 IFT="docker run -v `pwd`:/app -w /app ghcr.io/wilhelmuslab/ice-floe-tracker-pipeline/cli:{{ IFT_VERSION }}"
             {% elif IFT_INSTALL == "Apptainer" %}
-                IFT="apptainer run docker://ghcr.io/wilhelmuslab/ice-floe-tracker-pipeline/cli:{{ IFT_VERSION }}"
+                IFT="apptainer run --bind `pwd` docker://ghcr.io/wilhelmuslab/ice-floe-tracker-pipeline/cli:{{ IFT_VERSION }}"
             {% else %}
                 {{ raise('IFT_INSTALL not recognized.') }}
             {% endif %}


### PR DESCRIPTION
add binding of the current working directory in the apptainer IFT call

This may have been deactivated in the apptainer configuration for Oscar.