### PR TITLE
Add lookback days parameter to rotation measurement

### DIFF
--- a/IFTPipeline.jl/src/cli.jl
+++ b/IFTPipeline.jl/src/cli.jl
@@ -655,6 +655,12 @@ function mkcli_measure_rotation!(settings)
         "--output", "-o"
         help = "Tracked floes CSV file with rotations calculated"
         required = true
+
+        "--lookback_days", "-l"
+        help = "Number of days into the past to measure rotations"
+        required = false
+        arg_type = Int64
+        default = 1
     end
     return nothing
 end

--- a/IFTPipeline.jl/src/rotation.jl
+++ b/IFTPipeline.jl/src/rotation.jl
@@ -33,14 +33,21 @@ Columns returned:
   - if available: `satellite<i>`.
 """
 function measure_rotation(;
-    input::String, output::String, id_column=:ID, image_column=:mask, time_column=:passtime
+    input::String,
+    output::String,
+    id_column=:ID,
+    image_column=:mask,
+    time_column=:passtime,
+    lookback_days::Int64=1,
 )
     input_df = DataFrame(CSV.File(input))
 
     input_df[!, image_column] = eval.(Meta.parse.(input_df[:, image_column]))
     input_df[!, time_column] = ZonedDateTime.(String.(input_df[:, time_column]))
 
-    results_df = get_rotation_measurements(input_df; id_column, image_column, time_column)
+    results_df = get_rotation_measurements(
+        input_df; id_column, image_column, time_column, lookback_days
+    )
     @info results_df
 
     FileIO.save(output, results_df)

--- a/test/test-IFTPipeline.jl-cli.sh
+++ b/test/test-IFTPipeline.jl-cli.sh
@@ -189,6 +189,7 @@ track () {
     ${IFT} measure_rotation \
         -i ${DATA_ROOT}/paired.csv \
         -o ${DATA_ROOT}/paired.rotation.csv
+        --lookback-days 1
 
 }
 

--- a/workflow/flow.cylc
+++ b/workflow/flow.cylc
@@ -367,5 +367,6 @@
             --on-is-utc
         ${IFT} measure_rotation \
             -i ${tracked_floes_with_satellites} \
-            -o ${rotation_tracked_floes_file}
+            -o ${rotation_tracked_floes_file} \
+            -l ${ROTATION_LOOKBACK_DAYS}
         """

--- a/workflow/meta/rose-meta.conf
+++ b/workflow/meta/rose-meta.conf
@@ -325,3 +325,10 @@ description=Large floe area mismatch threshold
 
 [template variables=TRACK_SMALL_FLOE_AREA_MISMATCH_THRESHOLD]
 description=Small floe area mismatch threshold
+
+
+#--------------------------------------------------
+# Rotation
+#--------------------------------------------------
+[template variables=ROTATION_LOOKBACK_DAYS]
+description=Number of calendar days into the past to find matching floes for the rotation measurement

--- a/workflow/rose-suite.conf
+++ b/workflow/rose-suite.conf
@@ -139,3 +139,8 @@ TRACK_MM=0.22
 TRACK_CORR=0.68
 TRACK_LARGE_FLOE_AREA_MISMATCH_THRESHOLD=0.236
 TRACK_SMALL_FLOE_AREA_MISMATCH_THRESHOLD=0.18
+
+#--------------------------------------------------
+# Rotation
+#--------------------------------------------------
+ROTATION_LOOKBACK_DAYS=1


### PR DESCRIPTION
Pass the `lookback_days` parameter through from IceFloeTracker.jl